### PR TITLE
FEATURE: implements topic_required_words script

### DIFF
--- a/app/lib/discourse_automation/scripts/topic_required_words.rb
+++ b/app/lib/discourse_automation/scripts/topic_required_words.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Scriptable.add('topic_required_words') do
+  field :words, component: :text_list
+
+  version 1
+
+  triggerables %i[topic]
+end

--- a/app/lib/discourse_automation/triggers/topic.rb
+++ b/app/lib/discourse_automation/triggers/topic.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Triggerable::TOPIC = 'topic'
+
+DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::TOPIC) do
+  on_update do |automation, metadata, previous_metadata|
+    ActiveRecord::Base.transaction do
+      previous_topic_id = previous_metadata['topic_id']
+      topic_id = metadata['topic_id']
+      if previous_topic_id && previous_topic_id != topic_id
+        previous_topic = Topic.find_by(id: previous_topic_id)
+
+        if previous_topic
+          previous_topic.custom_fields.delete('discourse_automation_id')
+          previous_topic.save!
+        end
+      end
+
+      if topic_id
+        topic = Topic.find(topic_id)
+        topic && topic.upsert_custom_fields({ discourse_automation_id: automation.id })
+      end
+    end
+  end
+end

--- a/app/lib/discourse_automation/triggers/topic.rb
+++ b/app/lib/discourse_automation/triggers/topic.rb
@@ -17,7 +17,7 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::TOPIC) do
       end
 
       if topic_id
-        topic = Topic.find(topic_id)
+        topic = Topic.find_by(id: topic_id)
         topic && topic.upsert_custom_fields({ discourse_automation_id: automation.id })
       end
     end

--- a/app/models/discourse_automation/trigger.rb
+++ b/app/models/discourse_automation/trigger.rb
@@ -7,12 +7,18 @@ module DiscourseAutomation
     belongs_to :automation, class_name: 'DiscourseAutomation::Automation'
 
     def update_with_params(params)
+      old_metadata = automation.trigger.metadata
+
       automation.reset!
 
       update!(params)
 
       trigger = DiscourseAutomation::Triggerable.new(automation)
-      trigger.on_update.call(automation, params[:metadata])
+      trigger.on_update.call(
+        automation,
+        (params[:metadata] || {}).with_indifferent_access,
+        (old_metadata || {}).with_indifferent_access
+      )
     end
 
     def run!(trigger)

--- a/assets/javascripts/discourse/templates/components/point-in-time-trigger.hbs
+++ b/assets/javascripts/discourse/templates/components/point-in-time-trigger.hbs
@@ -1,6 +1,6 @@
 <div class="control-group">
   <label class="control-label">
-    {{i18n "discourse_automation.triggers.point_in_time.datetime.label"}}
+    {{i18n "discourse_automation.triggerables.point_in_time.datetime.label"}}
   </label>
 
   <div class="controls">

--- a/assets/javascripts/discourse/templates/components/topic-trigger.hbs
+++ b/assets/javascripts/discourse/templates/components/topic-trigger.hbs
@@ -1,0 +1,12 @@
+<div class="control-group">
+  <label class="control-label">
+    {{i18n "discourse_automation.triggerables.topic.topic_id.label"}}
+  </label>
+
+  <div class="controls">
+    {{input
+      value=metadata.topic_id
+      input=(action (mut metadata.topic_id) value="target.value")
+    }}
+  </div>
+</div>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -6,7 +6,7 @@ en:
       update: Update
       edit_automation:
         trigger_section:
-          title: When...
+          title: When/What...
         fields_section:
           title: Options
       destroy_automation:
@@ -40,11 +40,18 @@ en:
         point_in_time:
           datetime:
             label: Datetime
+        topic:
+          topic_id:
+            label: Topic ID
         post_created_edited:
           category:
             label: Category
             description: Optional, allows to limit trigger execution to this category
       scriptables:
+        topic_required_words:
+          fields:
+            words:
+              label: Required words list
         gift_exchange:
           fields:
             gift_exchangers_group:
@@ -62,10 +69,10 @@ en:
       models:
         trigger:
           name:
-            label: Name
+            label: Component
         automation:
           name:
-            label: Automation’s name
+            label: Name
           script:
             label: Script
           version:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,6 +9,8 @@ en:
         title: User added to group
       post_created_edited:
         title: Post created/edited
+      topic:
+        title: Topic
     scriptables:
       gift_exchange:
         title: Gift exchange
@@ -18,3 +20,9 @@ en:
         title: Send pms
         description: Allows to send PMs (possibly delated).
         doc: Allows to send multiple pms to a user. Each PM accepts a delay.
+      topic_required_words:
+        title: Topic required words
+        description: Allows to define a list of words required on a topic, at least one should be used in each post.
+        doc: Topic required words requires a topic. When a post is edited/created, the post will be validated against the list of words, at least one must be present.
+        errors:
+          must_include_word: "Post must include at least one of these words: %{words}"

--- a/plugin.rb
+++ b/plugin.rb
@@ -143,15 +143,7 @@ after_initialize do
             words = words.metadata['list']
 
             if words.present?
-              includes_at_least_one_word = false
-
-              words.each do |word|
-                if raw.include?(word)
-                  includes_at_least_one_word = true
-                end
-              end
-
-              if !includes_at_least_one_word
+              if words.none? { |word| raw.include?(word) }
                 errors.add(:base, I18n.t('discourse_automation.scriptables.topic_required_words.errors.must_include_word', words: words.join(', ')))
               end
             end

--- a/plugin.rb
+++ b/plugin.rb
@@ -32,8 +32,10 @@ after_initialize do
     '../app/lib/discourse_automation/triggers/user_added_to_group',
     '../app/lib/discourse_automation/triggers/point_in_time',
     '../app/lib/discourse_automation/triggers/post_created_edited',
+    '../app/lib/discourse_automation/triggers/topic',
     '../app/lib/discourse_automation/scripts/gift_exchange',
-    '../app/lib/discourse_automation/scripts/send_pms'
+    '../app/lib/discourse_automation/scripts/send_pms',
+    '../app/lib/discourse_automation/scripts/topic_required_words'
   ].each { |path| require File.expand_path(path, __FILE__) }
 
   module ::DiscourseAutomation
@@ -120,6 +122,43 @@ after_initialize do
           'post' => post
         )
       end
+  end
+
+  register_topic_custom_field_type('discourse_automation_id', :integer)
+
+  reloadable_patch do
+    require 'post'
+
+    class ::Post
+      validate :discourse_automation_topic_required_words
+
+      def discourse_automation_topic_required_words
+        if topic.custom_fields['discourse_automation_id'].present?
+          automation = DiscourseAutomation::Automation.find(topic.custom_fields['discourse_automation_id'])
+          if automation && automation.script == 'topic_required_words'
+            words = automation.fields.find { |field| field.name == 'words' }
+
+            return if !words
+
+            words = words.metadata['list']
+
+            if !words.blank?
+              includes_at_least_one_word = false
+
+              words.each do |word|
+                if raw.include?(word)
+                  includes_at_least_one_word = true
+                end
+              end
+
+              if !includes_at_least_one_word
+                errors.add(:base, I18n.t('discourse_automation.scriptables.topic_required_words.errors.must_include_word', words: words.join(', ')))
+              end
+            end
+          end
+        end
+      end
+    end
   end
 end
 

--- a/spec/jobs/discourse_automation_tracker_spec.rb
+++ b/spec/jobs/discourse_automation_tracker_spec.rb
@@ -18,7 +18,7 @@ describe Jobs::DiscourseAutomationTracker do
       )
 
       automation.create_trigger!(
-        name: Trigger::POINT_IN_TIME,
+        name: DiscourseAutomation::Triggerable::POINT_IN_TIME,
       )
 
       automation.fields.create!(

--- a/spec/models/trigger_spec.rb
+++ b/spec/models/trigger_spec.rb
@@ -24,7 +24,7 @@ describe DiscourseAutomation::Trigger do
         expect(automation.pending_automations.count).to eq(0)
 
         trigger = automation.create_trigger!(
-          name: Trigger::POINT_IN_TIME
+          name: DiscourseAutomation::Triggerable::POINT_IN_TIME
         )
         trigger.update_with_params(metadata: { execute_at: 2.hours.from_now })
 
@@ -33,7 +33,7 @@ describe DiscourseAutomation::Trigger do
 
       it 'destroys previous pending automation' do
         trigger = automation.create_trigger(
-          name: Trigger::POINT_IN_TIME
+          name: DiscourseAutomation::Triggerable::POINT_IN_TIME
         )
         trigger.update_with_params(metadata: { execute_at: 2.hours.from_now })
 

--- a/spec/scripts/topic_required_words_spec.rb
+++ b/spec/scripts/topic_required_words_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'TopicRequiredWords' do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:topic) { Fabricate(:topic) }
+  let!(:automation) do
+    DiscourseAutomation::Automation.create!(
+      name: 'Ensure word is present',
+      script: 'topic_required_words'
+    )
+  end
+
+  before do
+    automation.create_trigger!(name: 'topic', metadata: {})
+
+    automation.fields.create!(
+      component: 'text_list',
+      name: 'words',
+      metadata: { list: ['#foo', '#bar'] }
+    )
+  end
+
+  context 'editing/creating a post' do
+    before do
+      automation.trigger.update_with_params(metadata: { topic_id: topic.id })
+    end
+
+    context 'has a topic_required_words automation associated' do
+      context 'has at least a required word' do
+        it 'creates the post' do
+          post_creator = PostCreator.new(user, topic_id: topic.id, raw: 'this is quite cool #foo')
+          post = post_creator.create
+          expect(post.valid?).to be(true)
+        end
+      end
+
+      context 'has no required word' do
+        it 'doesn’t create the post' do
+          post_creator = PostCreator.new(user, topic_id: topic.id, raw: 'this is quite cool')
+          post = post_creator.create
+          expect(post.valid?).to be(false)
+        end
+      end
+    end
+  end
+end

--- a/spec/scripts/topic_required_words_spec.rb
+++ b/spec/scripts/topic_required_words_spec.rb
@@ -27,20 +27,31 @@ describe 'TopicRequiredWords' do
       automation.trigger.update_with_params(metadata: { topic_id: topic.id })
     end
 
-    context 'has a topic_required_words automation associated' do
-      context 'has at least a required word' do
-        it 'creates the post' do
+    context 'topic has a topic_required_words automation associated' do
+      context 'post has at least a required word' do
+        it 'validates the post' do
           post_creator = PostCreator.new(user, topic_id: topic.id, raw: 'this is quite cool #foo')
           post = post_creator.create
           expect(post.valid?).to be(true)
         end
       end
 
-      context 'has no required word' do
-        it 'doesn’t create the post' do
+      context 'post has no required word' do
+        it 'doesn’t validate the post' do
           post_creator = PostCreator.new(user, topic_id: topic.id, raw: 'this is quite cool')
           post = post_creator.create
           expect(post.valid?).to be(false)
+        end
+      end
+    end
+
+    context 'topic has no topic_required_words automation associated' do
+      context 'post has no required word' do
+        it 'validates the post' do
+          no_automation_topic = create_topic
+          post_creator = PostCreator.new(user, topic_id: no_automation_topic.id, raw: 'this is quite cool')
+          post = post_creator.create
+          expect(post.valid?).to be(true)
         end
       end
     end

--- a/spec/triggers/topic_spec.rb
+++ b/spec/triggers/topic_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'TopicRequiredWords' do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:topic) { Fabricate(:topic) }
+  let!(:automation) do
+    DiscourseAutomation::Automation.create!(
+      name: 'Ensure word is present',
+      script: 'topic_required_words'
+    )
+  end
+
+  before do
+    automation.create_trigger!(name: 'topic', metadata: {})
+  end
+
+  context 'updating trigger' do
+    it 'updates the custom field' do
+      automation.trigger.update_with_params(metadata: { topic_id: topic.id })
+      expect(topic.custom_fields['discourse_automation_id']).to eq(automation.id)
+
+      new_topic = create_topic
+      automation.trigger.update_with_params(metadata: { topic_id: new_topic.id })
+      expect(new_topic.custom_fields['discourse_automation_id']).to eq(automation.id)
+    end
+  end
+end


### PR DESCRIPTION
This commit also introduces the topic trigger which let's an automation mark a topic has "automation-able" (through a custom field), scripts and other utilities can then check if a topic is automation-able before applying any logic on it.