### PR TITLE
FEATURE: Add user_promoted trigger and event hook

### DIFF
--- a/app/lib/discourse_automation/scripts/send_pms.rb
+++ b/app/lib/discourse_automation/scripts/send_pms.rb
@@ -12,7 +12,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::SEND_PMS) d
   field :receiver, component: :user, triggerable: :recurring
   field :sendable_pms, component: :pms, accepts_placeholders: true
 
-  triggerables %i[user_added_to_group stalled_wiki recurring]
+  triggerables %i[user_added_to_group stalled_wiki recurring user_promoted]
 
   script do |context, fields, automation|
     sender_username = fields.dig('sender', 'value') || Discourse.system_user.username

--- a/app/lib/discourse_automation/triggers/user_promoted.rb
+++ b/app/lib/discourse_automation/triggers/user_promoted.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Triggerable::USER_PROMOTED = 'user_promoted'
+
+DiscourseAutomation::Triggerable::USER_PROMOTED_TRUST_LEVEL_CHOICES = [
+  { id: 'TLALL', name: 'discourse_automation.triggerables.user_promoted.trust_levels.ALL' },
+  { id: 'TL01', name: 'discourse_automation.triggerables.user_promoted.trust_levels.TL01' },
+  { id: 'TL12', name: 'discourse_automation.triggerables.user_promoted.trust_levels.TL12' },
+  { id: 'TL23', name: 'discourse_automation.triggerables.user_promoted.trust_levels.TL23' },
+  { id: 'TL34', name: 'discourse_automation.triggerables.user_promoted.trust_levels.TL34' },
+]
+
+DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_PROMOTED) do
+  field :restricted_group, component: :group
+  field :trust_level_transition, component: :choices, extra: {
+    content: DiscourseAutomation::Triggerable::USER_PROMOTED_TRUST_LEVEL_CHOICES
+  }
+
+  placeholder :trust_level_transition
+end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -85,6 +85,18 @@ en:
           fields:
             joined_group:
               label: Tracked group
+        user_promoted:
+          fields:
+            restricted_group:
+              label: Restrict to group
+            trust_level_transition:
+              label: Trust level transition
+          trust_levels:
+            ALL: "All trust levels"
+            TL01: "TL0 to TL1"
+            TL12: "TL1 to TL2"
+            TL23: "TL2 to TL3"
+            TL34: "TL3 to TL4"
         point_in_time:
           fields:
             execute_at:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -15,6 +15,10 @@ en:
       user_added_to_group:
         title: User added to group
         description: When a user is added to the specified group the automation will be triggered
+      user_promoted:
+        title: User promoted
+        description: When a user is promoted from one trust level to another
+        transition_placeholder: "from %{from_level_name} to %{to_level_name}"
       stalled_wiki:
         title: Stalled wiki
         description: When a wiki has not been edited for a period longer than the one defined, the automation will be triggered

--- a/spec/triggers/user_promoted_spec.rb
+++ b/spec/triggers/user_promoted_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe 'UserPromoted' do
+  fab!(:user) { Fabricate(:user, trust_level: TrustLevel[0]) }
+  fab!(:automation) { Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::USER_PROMOTED) }
+
+  it "runs without any restrictions" do
+    output = capture_stdout do
+      user.change_trust_level!(TrustLevel[1])
+    end
+    expect(output).to include('"kind":"user_promoted"')
+    expect(output).to include('"placeholders":{"trust_level_transition":"from new user to basic user"}}')
+  end
+
+  it "does not run if the user is being demoted" do
+    user.change_trust_level!(TrustLevel[4])
+    output = capture_stdout do
+      user.change_trust_level!(TrustLevel[1])
+    end
+    expect(output).not_to include('"kind":"user_promoted"')
+  end
+
+  context "when there is a group restriction" do
+    let!(:group) { Fabricate(:group) }
+    before do
+      automation.upsert_field!("restricted_group", "group", { "value" => group.id }, target: "trigger")
+    end
+    
+    it "does not run if the user is not part of the group" do
+      output = capture_stdout do
+        user.change_trust_level!(TrustLevel[1])
+      end
+      expect(output).not_to include('"kind":"user_promoted"')
+    end
+    
+    it "does run if the user is part of the group" do
+      Fabricate(:group_user, group: group, user: user)
+      output = capture_stdout do
+        user.change_trust_level!(TrustLevel[1])
+      end
+      expect(output).to include('"kind":"user_promoted"')
+    end
+  end
+
+  context "when there is a trust_level_transition restriction" do
+    before do
+      automation.upsert_field!("trust_level_transition", "choices", { "value" => "TL01" }, target: "trigger")
+    end
+
+    it "does not run if the trust level transition does not match" do
+      user.change_trust_level!(TrustLevel[2])
+      output = capture_stdout do
+        user.change_trust_level!(TrustLevel[3])
+      end
+      expect(output).not_to include('"kind":"user_promoted"')
+    end
+
+    it "does run if the trust level transition matches" do
+      user.change_trust_level!(TrustLevel[0])
+      output = capture_stdout do
+        user.change_trust_level!(TrustLevel[1])
+      end
+      expect(output).to include('"kind":"user_promoted"')
+    end
+
+    it "does run if the transition is for all trust levels" do
+      automation.upsert_field!("trust_level_transition", "choices", { "value" => "TLALL" }, target: "trigger")
+      user.change_trust_level!(TrustLevel[2])
+      output = capture_stdout do
+        user.change_trust_level!(TrustLevel[4])
+      end
+      expect(output).to include('"kind":"user_promoted"')
+    end
+  end
+end
+


### PR DESCRIPTION
Added the new user_promoted trigger which has the following fields:

* restricted_group:       Will only run the script if the user being promoted
                          is in the specified group.
* trust_level_transition: Will only run the script if old to new trust
                          level matches what is specified here (e.g. 1
                          to 2), or for all trust level promotions.

We use the `:user_promoted event` from core for this new trigger. We do
not fire the automation trigger if the "promotion" is actually a
demotion e.g. 4 -> 1. We may want a separate event in core for this at
some point.