### PR TITLE
DEV: adds plugin triggerable API

### DIFF
--- a/app/core_ext/plugin_instance.rb
+++ b/app/core_ext/plugin_instance.rb
@@ -6,4 +6,16 @@ class Plugin::Instance
       DiscourseAutomation::Scriptable.add(name, &block)
     end
   end
+
+  def add_automation_triggerable(name, &block)
+    reloadable_patch do
+      DiscourseAutomation::Triggerable.add(name, &block)
+    end
+  end
+
+  def add_triggerable_to_scriptable(triggerable, scriptable)
+    reloadable_patch do
+      DiscourseAutomation::Scriptable.add_plugin_triggerable(triggerable, scriptable)
+    end
+  end
 end

--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -4,12 +4,25 @@ module DiscourseAutomation
   class Scriptable
     attr_reader :fields, :name, :not_found, :forced_triggerable
 
+    @@plugin_triggerables ||= {}
+
+    class << self
+      def add_plugin_triggerable(triggerable, scriptable)
+        @@plugin_triggerables[scriptable.to_sym] ||= []
+        @@plugin_triggerables[scriptable.to_sym] << triggerable.to_sym
+      end
+
+      def plugin_triggerables
+        @@plugin_triggerables
+      end
+    end
+
     def initialize(name)
       @name = name
       @version = 0
       @fields = []
       @placeholders = [:site_title]
-      @triggerables = []
+      @triggerables = (@@plugin_triggerables[name.to_sym] || []) + []
       @script = proc {}
       @not_found = false
       @forced_triggerable = nil
@@ -69,7 +82,7 @@ module DiscourseAutomation
 
     def triggerables(*args)
       if args.present?
-        @triggerables, = args
+        @triggerables.push(*args[0])
       else
         forced_triggerable ? [forced_triggerable[:triggerable]] : @triggerables
       end

--- a/spec/integration/core_ext_spec.rb
+++ b/spec/integration/core_ext_spec.rb
@@ -6,6 +6,18 @@ describe 'Core extensions' do
   fab!(:automation_1) { Fabricate(:automation) }
   fab!(:automation_2) { Fabricate(:automation) }
 
+  context 'plugin_api' do
+    describe '#add_triggerable_to_scriptable' do
+      it 'adds the triggerable as a possibility for a scriptable' do
+        DiscourseAutomation::Triggerable.add(:foo) {}
+        DiscourseAutomation::Scriptable.add(:bar) {}
+        DiscourseAutomation::Scriptable.add_plugin_triggerable(:foo, :bar)
+
+        expect(DiscourseAutomation::Scriptable.plugin_triggerables[:bar]).to contain_exactly(:foo)
+      end
+    end
+  end
+
   describe 'post custom fields' do
     it 'supports discourse_automation_ids' do
       post = create_post

--- a/spec/integration/core_ext_spec.rb
+++ b/spec/integration/core_ext_spec.rb
@@ -9,11 +9,30 @@ describe 'Core extensions' do
   context 'plugin_api' do
     describe '#add_triggerable_to_scriptable' do
       it 'adds the triggerable as a possibility for a scriptable' do
-        DiscourseAutomation::Triggerable.add(:foo) {}
-        DiscourseAutomation::Scriptable.add(:bar) {}
-        DiscourseAutomation::Scriptable.add_plugin_triggerable(:foo, :bar)
+        plugin = Plugin::Instance.new nil, '/tmp/test.rb'
+        plugin.add_automation_triggerable(:bar) {}
+        plugin.add_automation_scriptable(:foo) {}
+        plugin.add_triggerable_to_scriptable(:foo, :bar)
 
         expect(DiscourseAutomation::Scriptable.plugin_triggerables[:bar]).to contain_exactly(:foo)
+      end
+    end
+
+    describe '#add_automation_triggerable' do
+      it 'adds the triggerable' do
+        plugin = Plugin::Instance.new nil, '/tmp/test.rb'
+        plugin.add_automation_triggerable(:foo) {}
+
+        expect(DiscourseAutomation::Triggerable.all).to include(:__triggerable_foo)
+      end
+    end
+
+    describe '#add_automation_scriptable' do
+      it 'adds the scriptable' do
+        plugin = Plugin::Instance.new nil, '/tmp/test.rb'
+        plugin.add_automation_scriptable(:foo) {}
+
+        expect(DiscourseAutomation::Scriptable.all).to include(:__scriptable_foo)
       end
     end
   end


### PR DESCRIPTION
This API allows plugins to add a defined triggerable as valid triggerable for a scriptable.

eg:

```
add_automation_triggerable(:foo) {}

add_triggerable_to_scriptable(:foo, :send_pms)
```

Note this commit also adds a missing `add_automation_triggerable` API