### PR TITLE
FEATURE: adds auto_responder script

### DIFF
--- a/app/lib/discourse_automation/scripts/auto_responder.rb
+++ b/app/lib/discourse_automation/scripts/auto_responder.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Scriptable::AUTO_RESPONDER = 'auto_responder'
+
+DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_RESPONDER) do
+  field :word_answer_list, component: :'key-value', accepts_placeholders: true
+  field :answering_user, component: :user
+
+  version 1
+
+  triggerables [:post_created_edited]
+
+  placeholder :sender_username
+  placeholder :word
+
+  script do |context, fields|
+    answering_username = fields.dig('answering_user', 'value') || Discourse.system_user.username
+    placeholders = {
+      sender_username: answering_username
+    }
+    post = context['post']
+
+    answers = Set.new
+    tuples = JSON.load(fields.dig('word_answer_list', 'value'))
+    tuples.each do |tuple|
+      if post.raw.include?(tuple['key'])
+        answers.add(tuple)
+      end
+    end
+
+    answering_user = User.find_by(username: answering_username)
+    if post.user == answering_user
+      next
+    end
+
+    replies = post.replies
+      .where(user_id: answering_user.id, deleted_at: nil)
+      .secured(Guardian.new(post.user))
+
+    if answers.length > 0 && replies.length == 0
+      answers = answers.to_a.map do |answer|
+        utils.apply_placeholders(answer['value'], placeholders.merge(key: answer['key']))
+      end.join("\n\n")
+
+      PostCreator.create!(
+        answering_user,
+        topic_id: post.topic.id,
+        reply_to_post_number: post.post_number,
+        raw: answers,
+        skip_validations: true
+      )
+    end
+  end
+end

--- a/app/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/app/lib/discourse_automation/triggers/post_created_edited.rb
@@ -4,4 +4,5 @@ DiscourseAutomation::Triggerable::POST_CREATED_EDITED = 'post_created_edited'
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::POST_CREATED_EDITED) do
   field :restricted_category, component: :category
+  field :valid_trust_levels, component: :'trust-levels'
 end

--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -62,6 +62,22 @@ module DiscourseAutomation
     end
 
     SCHEMAS = {
+      'key-value' => {
+        'type' => "array",
+        'uniqueItems' => true,
+        'items' => {
+          'type' => "object",
+          'title' => "group",
+          'properties' => {
+            'key' => {
+              'type' => "string"
+            },
+            'value' => {
+              'type' => "string"
+            }
+          }
+        }
+      },
       'choices' => {
         'value' => {
           'type' => ['string', 'integer']
@@ -71,6 +87,12 @@ module DiscourseAutomation
         'value' => {
           'type' => 'array',
           'items' => [{ 'type': 'string' }]
+        }
+      },
+      'trust-levels' => {
+        'value' => {
+          'type' => 'array',
+          'items' => [{ 'type': 'integer' }]
         }
       },
       'categories' => {

--- a/assets/javascripts/discourse/components/automation-field.js.es6
+++ b/assets/javascripts/discourse/components/automation-field.js.es6
@@ -15,20 +15,20 @@ export default Component.extend({
     return triggerId && (!triggerable || triggerable === triggerId);
   },
 
-  placeholdersString: computed("field.placeholders", function() {
+  placeholdersString: computed("field.placeholders", function () {
     return this.field.placeholders.join(", ");
   }),
 
-  target: computed("field.target", function() {
+  target: computed("field.target", function () {
     return this.field.target === "script"
       ? `.scriptables.${this.automation.script.id.replace(/-/g, "_")}.`
       : `.triggerables.${this.automation.trigger.id.replace(/-/g, "_")}.`;
   }),
 
-  description: computed("target", function() {
+  description: computed("target", function () {
     return I18n.lookup(
       `discourse_automation${this.target}fields.${this.field.name}.description`,
       { locale: I18n.locale }
     );
-  })
+  }),
 });

--- a/assets/javascripts/discourse/components/automation-field.js.es6
+++ b/assets/javascripts/discourse/components/automation-field.js.es6
@@ -7,6 +7,7 @@ export default Component.extend({
   tagName: "",
   field: null,
   automation: null,
+  saveAutomation: null,
   tagName: "",
 
   @discourseComputed("automation.trigger.id", "field.triggerable")
@@ -14,20 +15,20 @@ export default Component.extend({
     return triggerId && (!triggerable || triggerable === triggerId);
   },
 
-  placeholdersString: computed("field.placeholders", function () {
+  placeholdersString: computed("field.placeholders", function() {
     return this.field.placeholders.join(", ");
   }),
 
-  target: computed("field.target", function () {
+  target: computed("field.target", function() {
     return this.field.target === "script"
       ? `.scriptables.${this.automation.script.id.replace(/-/g, "_")}.`
       : `.triggerables.${this.automation.trigger.id.replace(/-/g, "_")}.`;
   }),
 
-  description: computed("target", function () {
+  description: computed("target", function() {
     return I18n.lookup(
       `discourse_automation${this.target}fields.${this.field.name}.description`,
       { locale: I18n.locale }
     );
-  }),
+  })
 });

--- a/assets/javascripts/discourse/components/fields/da-base-field.js.es6
+++ b/assets/javascripts/discourse/components/fields/da-base-field.js.es6
@@ -5,9 +5,10 @@ export default Component.extend({
   tagName: "",
   placeholders: null,
   field: null,
+  saveAutomation: null,
 
   @discourseComputed("placeholders.length", "field.acceptsPlaceholders")
   displayPlaceholders(hasPlaceholders, acceptsPlaceholders) {
     return hasPlaceholders && acceptsPlaceholders;
-  },
+  }
 });

--- a/assets/javascripts/discourse/components/fields/da-base-field.js.es6
+++ b/assets/javascripts/discourse/components/fields/da-base-field.js.es6
@@ -10,5 +10,5 @@ export default Component.extend({
   @discourseComputed("placeholders.length", "field.acceptsPlaceholders")
   displayPlaceholders(hasPlaceholders, acceptsPlaceholders) {
     return hasPlaceholders && acceptsPlaceholders;
-  }
+  },
 });

--- a/assets/javascripts/discourse/components/fields/da-key-value-field.js.es6
+++ b/assets/javascripts/discourse/components/fields/da-key-value-field.js.es6
@@ -1,0 +1,41 @@
+import showModal from "discourse/lib/show-modal";
+import BaseField from "./da-base-field";
+import { action } from "@ember/object";
+
+export default BaseField.extend({
+  @action
+  openSchemaModal() {
+    const jsonSchemaEditorModal = showModal("json-schema-editor", {
+      model: {
+        value:
+          this.field.metadata.value ||
+          '[{"key":"example","value":"You posted %%KEY%%"}]',
+        settingName: this.label,
+        jsonSchema: {
+          type: "array",
+          uniqueItems: true,
+          items: {
+            type: "object",
+            title: "group",
+            properties: {
+              key: {
+                type: "string",
+              },
+              value: {
+                type: "string",
+                format: "textarea",
+              },
+            },
+          },
+        },
+      },
+    });
+
+    jsonSchemaEditorModal.set("onClose", () => {
+      if (jsonSchemaEditorModal.model.value !== this.field.metadata.value) {
+        this.set("field.metadata.value", jsonSchemaEditorModal.model.value);
+        this.saveAutomation();
+      }
+    });
+  },
+});

--- a/assets/javascripts/discourse/components/fields/da-trust-levels-field.js.es6
+++ b/assets/javascripts/discourse/components/fields/da-trust-levels-field.js.es6
@@ -1,6 +1,6 @@
 import BaseField from "./da-base-field";
-import Site from "discourse/models/site";
+import { reads } from "@ember/object/computed";
 
 export default BaseField.extend({
-  allTrustLevel: Site.currentProp("trustLevels"),
+  allTrustLevel: reads("site.trustLevels"),
 });

--- a/assets/javascripts/discourse/components/fields/da-trust-levels-field.js.es6
+++ b/assets/javascripts/discourse/components/fields/da-trust-levels-field.js.es6
@@ -1,0 +1,6 @@
+import BaseField from "./da-base-field";
+import Site from "discourse/models/site";
+
+export default BaseField.extend({
+  allTrustLevel: Site.currentProp("trustLevels"),
+});

--- a/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
@@ -112,6 +112,7 @@
             automation=automation
             field=field
             onChangeField=(action "onChangeField")
+            saveAutomation=(action "saveAutomation" automation)
           }}
         {{/each}}
       {{/if}}
@@ -136,6 +137,7 @@
                 automation=automation
                 field=field
                 onChangeField=(action "onChangeField")
+                saveAutomation=(action "saveAutomation" automation)
               }}
             {{/each}}
           </div>

--- a/assets/javascripts/discourse/templates/components/automation-field.hbs
+++ b/assets/javascripts/discourse/templates/components/automation-field.hbs
@@ -5,5 +5,6 @@
     onChangeField=onChangeField
     label=(i18n (concat "discourse_automation" target "fields." field.name ".label"))
     description=description
+    saveAutomation=saveAutomation
   }}
 {{/if}}

--- a/assets/javascripts/discourse/templates/components/fields/da-key-value-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-key-value-field.hbs
@@ -1,0 +1,14 @@
+<section class="field key-value-field">
+  <div class="control-group">
+    {{fields/da-field-label label=label field=field}}
+
+    <div class="controls">
+      {{d-button
+        label="discourse_automation.fields.key_value.label"
+        action=(action "openSchemaModal")
+      }}
+
+      {{fields/da-field-description description=description}}
+    </div>
+  </div>
+</section>

--- a/assets/javascripts/discourse/templates/components/fields/da-trust-levels-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-trust-levels-field.hbs
@@ -1,0 +1,15 @@
+<section class="field category-field">
+  <div class="control-group">
+    {{fields/da-field-label label=label field=field}}
+
+    <div class="controls">
+      {{multi-select
+        value=field.metadata.value
+        content=allTrustLevel
+        onChange=(action (mut field.metadata.value))
+      }}
+
+      {{fields/da-field-description description=description}}
+    </div>
+  </div>
+</section>

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -135,7 +135,7 @@ en:
         auto_responder:
           fields:
             word_answer_list:
-              label: List of word/answer
+              label: List of word/answer pairs
               description: Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. Note that `value` accepts `%%KEY%%` as a placeholder to be replaced by the value of `key` in the reply.
             answering_user:
               label: Answering user

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -19,6 +19,8 @@ en:
       destroy_automation:
         confirm: "Are you sure you want to delete `%{name}`?"
       fields:
+        key_value:
+          label: Configure
         user:
           label: User
         pm:
@@ -122,11 +124,22 @@ en:
               label: Topic ID
         post_created_edited:
           fields:
+            valid_trust_levels:
+              label: Valid trust levels
+              description: Will trigger only if post is created by user in these trust levels, defaults to any trust level
             restricted_category:
               label: Category
               description: Optional, allows to limit trigger execution to this category
       scriptables:
         not_found: Couldn’t find script `%{script}` for automation `%{automation}`, ensure the associated plugin is installed
+        auto_responder:
+          fields:
+            word_answer_list:
+              label: List of word/answer
+              description: Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. Note that `value` accepts `%%KEY%%` as a placeholder to be replaced by the value of `key` in the reply.
+            answering_user:
+              label: Answering user
+              description: Defaults to System user
         user_global_notice:
           fields:
             level:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -42,6 +42,9 @@ en:
         description: Flags a post if it contains specified words
         flag_message: "Post contains disallowed words: %{words}"
         doc: Post containing all given words at once will be flagged and hidden. Note that defining multiple words delimited by a comma will be used as compound (each word has to be present).
+      auto_responder:
+        title: Auto Responder
+        description: Posts a reply to a post including specified keywords
       pin_topic:
         title: Pin Topic
         description: Pins a specified topic at a given date

--- a/plugin.rb
+++ b/plugin.rb
@@ -23,6 +23,11 @@ def handle_post_created_edited(post, action)
   DiscourseAutomation::Automation
     .where(trigger: name, enabled: true)
     .find_each do |automation|
+      valid_trust_levels = automation.trigger_field('valid_trust_levels')
+      if valid_trust_levels['value']
+        next unless valid_trust_levels['value'].include?(post.user.trust_level)
+      end
+
       restricted_category = automation.trigger_field('restricted_category')
       if restricted_category['value']
         category_id = post.topic&.category&.parent_category&.id || post.topic&.category&.id
@@ -103,6 +108,7 @@ after_initialize do
     '../app/jobs/scheduled/stalled_topic_tracker',
     '../app/lib/discourse_automation/triggers/recurring',
     '../app/lib/discourse_automation/triggers/user_promoted',
+    '../app/lib/discourse_automation/scripts/auto_responder',
     '../app/lib/discourse_automation/scripts/banner_topic',
     '../app/lib/discourse_automation/scripts/suspend_user_by_email',
     '../app/lib/discourse_automation/scripts/pin_topic',

--- a/spec/scripts/auto_responder_spec.rb
+++ b/spec/scripts/auto_responder_spec.rb
@@ -4,7 +4,7 @@ require_relative '../discourse_automation_helper'
 
 describe 'AutoResponder' do
   before do
-    automation.upsert_field!('word_answer_list', 'key-value', {value: [{ key: 'foo', value: 'this is foo' }, { key: 'bar', value: 'this is bar' }].to_json })
+    automation.upsert_field!('word_answer_list', 'key-value', { value: [{ key: 'foo', value: 'this is foo' }, { key: 'bar', value: 'this is bar' }].to_json })
   end
 
   fab!(:automation) do

--- a/spec/scripts/auto_responder_spec.rb
+++ b/spec/scripts/auto_responder_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe 'AutoResponder' do
+  before do
+    automation.upsert_field!('word_answer_list', 'key-value', {value: [{ key: 'foo', value: 'this is foo' }, { key: 'bar', value: 'this is bar' }].to_json })
+  end
+
+  fab!(:automation) do
+    Fabricate(
+      :automation,
+      script: DiscourseAutomation::Scriptable::AUTO_RESPONDER
+    )
+  end
+  fab!(:topic) { Fabricate(:topic) }
+
+  context 'post contains a keyword' do
+    it 'creates an answer' do
+      post = create_post(topic: topic, raw: 'this is a post with foo')
+      automation.trigger!('post' => post)
+
+      expect(topic.reload.posts.last.raw).to eq('this is foo')
+    end
+
+    context 'post has direct replies from answering user' do
+      fab!(:answering_user) { Fabricate(:user) }
+
+      before do
+        automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
+      end
+
+      it 'doesn’t create another answer' do
+        post_1 = create_post(topic: topic, raw: 'this is a post with foo')
+        create_post(user: answering_user, reply_to_post_number: post_1.post_number, topic: topic)
+
+        expect {
+          automation.trigger!('post' => post_1)
+        }.to change {
+          Post.count
+        }.by(0)
+      end
+    end
+
+    context 'user is replying to own post' do
+      fab!(:answering_user) { Fabricate(:user) }
+
+      before do
+        automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
+      end
+
+      it 'doesn’t create an answer' do
+        post_1 = create_post(topic: topic)
+        post_2 = create_post(user: answering_user, topic: topic, reply_to_post_number: post_1.post_number, raw: 'this is a post with foo')
+
+        expect {
+          automation.trigger!('post' => post_2)
+        }.to change {
+          Post.count
+        }.by(0)
+      end
+    end
+  end
+
+  context 'post contains two keywords' do
+    it 'creates an answer with both answers' do
+      post = create_post(topic: topic, raw: 'this is a post with foo and bar')
+      automation.trigger!('post' => post)
+
+      expect(topic.reload.posts.last.raw).to eq("this is foo\n\nthis is bar")
+    end
+  end
+
+  context 'post doesn’t contain a keyword' do
+    it 'doesn’t create an answer' do
+      post = create_post(topic: topic, raw: 'this is a post with no keyword')
+
+      expect {
+        automation.trigger!('post' => post)
+      }.to change {
+        Post.count
+      }.by(0)
+    end
+  end
+end

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -30,6 +30,34 @@ describe 'PostCreatedEdited' do
       expect(output['action']).to eq('edit')
     end
 
+    context 'trust_levels are restricted' do
+      before do
+        automation.upsert_field!('valid_trust_levels', 'trust-levels', { value: [0] }, target: 'trigger')
+      end
+
+      context 'trust level is allowed' do
+        it 'fires the trigger' do
+          output = JSON.load(capture_stdout do
+            user.trust_level = TrustLevel[0]
+            PostCreator.create(user, basic_topic_params)
+          end)
+
+          expect(output['kind']).to eq('post_created_edited')
+        end
+      end
+
+      context 'trust level is not allowed' do
+        it 'doesn’t fire the trigger' do
+          output = JSON.load(capture_stdout do
+            user.trust_level = TrustLevel[1]
+            PostCreator.create(user, basic_topic_params)
+          end)
+
+          expect(output).to be_nil
+        end
+      end
+    end
+
     context 'category is restricted' do
       before do
         automation.upsert_field!('restricted_category', 'category', { value: Category.first.id }, target: 'trigger')


### PR DESCRIPTION
The auto responder script allows to define a list of keys/values which will be used to react to a post content. If a post contains KEY, then a reply using VALUE will be made to the post.

Note that this commit also introduces the ability for the post_created_edited trigger to limit its action to specific trust_levels creators.