### PR TITLE
FIX: an empty word/answer list doesn’t generate an exception

### DIFF
--- a/app/lib/discourse_automation/scripts/auto_responder.rb
+++ b/app/lib/discourse_automation/scripts/auto_responder.rb
@@ -22,6 +22,9 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_RESPON
 
     answers = Set.new
     tuples = JSON.load(fields.dig('word_answer_list', 'value'))
+
+    next if tuples.blank?
+
     tuples.each do |tuple|
       if post.raw.match(/\b#{tuple['key']}\b/)
         answers.add(tuple)

--- a/spec/scripts/auto_responder_spec.rb
+++ b/spec/scripts/auto_responder_spec.rb
@@ -3,9 +3,7 @@
 require_relative '../discourse_automation_helper'
 
 describe 'AutoResponder' do
-  before do
-    automation.upsert_field!('word_answer_list', 'key-value', { value: [{ key: 'foo', value: 'this is foo' }, { key: 'bar', value: 'this is bar' }].to_json })
-  end
+  fab!(:topic) { Fabricate(:topic) }
 
   fab!(:automation) do
     Fabricate(
@@ -13,73 +11,108 @@ describe 'AutoResponder' do
       script: DiscourseAutomation::Scriptable::AUTO_RESPONDER
     )
   end
-  fab!(:topic) { Fabricate(:topic) }
 
-  context 'post contains a keyword' do
-    it 'creates an answer' do
-      post = create_post(topic: topic, raw: 'this is a post with foo')
-      automation.trigger!('post' => post)
-
-      expect(topic.reload.posts.last.raw).to eq('this is foo')
+  context 'present word_answer list' do
+    before do
+      automation.upsert_field!('word_answer_list', 'key-value', { value: [{ key: 'foo', value: 'this is foo' }, { key: 'bar', value: 'this is bar' }].to_json })
     end
 
-    context 'post has direct replies from answering user' do
-      fab!(:answering_user) { Fabricate(:user) }
-
-      before do
-        automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
-      end
-
-      it 'doesn’t create another answer' do
-        post_1 = create_post(topic: topic, raw: 'this is a post with foo')
-        create_post(user: answering_user, reply_to_post_number: post_1.post_number, topic: topic)
-
-        expect {
-          automation.trigger!('post' => post_1)
-        }.to change {
-          Post.count
-        }.by(0)
-      end
-    end
-
-    context 'user is replying to own post' do
-      fab!(:answering_user) { Fabricate(:user) }
-
-      before do
-        automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
-      end
-
-      it 'doesn’t create an answer' do
-        post_1 = create_post(topic: topic)
-        post_2 = create_post(user: answering_user, topic: topic, reply_to_post_number: post_1.post_number, raw: 'this is a post with foo')
-
-        expect {
-          automation.trigger!('post' => post_2)
-        }.to change {
-          Post.count
-        }.by(0)
-      end
-    end
-  end
-
-  context 'post contains two keywords' do
-    it 'creates an answer with both answers' do
-      post = create_post(topic: topic, raw: 'this is a post with foo and bar')
-      automation.trigger!('post' => post)
-
-      expect(topic.reload.posts.last.raw).to eq("this is foo\n\nthis is bar")
-    end
-  end
-
-  context 'post doesn’t contain a keyword' do
-    it 'doesn’t create an answer' do
-      post = create_post(topic: topic, raw: 'this is a post bfoo with no keyword fooa')
-
-      expect {
+    context 'post contains a keyword' do
+      it 'creates an answer' do
+        post = create_post(topic: topic, raw: 'this is a post with foo')
         automation.trigger!('post' => post)
-      }.to change {
-        Post.count
-      }.by(0)
+
+        expect(topic.reload.posts.last.raw).to eq('this is foo')
+      end
+
+      context 'post has direct replies from answering user' do
+        fab!(:answering_user) { Fabricate(:user) }
+
+        before do
+          automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
+        end
+
+        it 'doesn’t create another answer' do
+          post_1 = create_post(topic: topic, raw: 'this is a post with foo')
+          create_post(user: answering_user, reply_to_post_number: post_1.post_number, topic: topic)
+
+          expect {
+            automation.trigger!('post' => post_1)
+          }.to change {
+            Post.count
+          }.by(0)
+        end
+      end
+
+      context 'user is replying to own post' do
+        fab!(:answering_user) { Fabricate(:user) }
+
+        before do
+          automation.upsert_field!('answering_user', 'user', { value: answering_user.username }, target: 'script')
+        end
+
+        it 'doesn’t create an answer' do
+          post_1 = create_post(topic: topic)
+          post_2 = create_post(user: answering_user, topic: topic, reply_to_post_number: post_1.post_number, raw: 'this is a post with foo')
+
+          expect {
+            automation.trigger!('post' => post_2)
+          }.to change {
+            Post.count
+          }.by(0)
+        end
+      end
+    end
+
+    context 'post contains two keywords' do
+      it 'creates an answer with both answers' do
+        post = create_post(topic: topic, raw: 'this is a post with foo and bar')
+        automation.trigger!('post' => post)
+
+        expect(topic.reload.posts.last.raw).to eq("this is foo\n\nthis is bar")
+      end
+    end
+
+    context 'post doesn’t contain a keyword' do
+      it 'doesn’t create an answer' do
+        post = create_post(topic: topic, raw: 'this is a post with no keyword')
+
+        expect {
+          automation.trigger!('post' => post)
+        }.to change {
+          Post.count
+        }.by(0)
+      end
+    end
+
+    context 'post contains two keywords' do
+      it 'creates an answer with both answers' do
+        post = create_post(topic: topic, raw: 'this is a post with foo and bar')
+        automation.trigger!('post' => post)
+
+        expect(topic.reload.posts.last.raw).to eq("this is foo\n\nthis is bar")
+      end
+    end
+
+    context 'post doesn’t contain a keyword' do
+      it 'doesn’t create an answer' do
+        post = create_post(topic: topic, raw: 'this is a post bfoo with no keyword fooa')
+
+        expect {
+          automation.trigger!('post' => post)
+        }.to change {
+          Post.count
+        }.by(0)
+      end
+    end
+  end
+
+  context 'empty word_answer list' do
+    it 'exits early with no error' do
+      expect {
+        post = create_post(topic: topic, raw: 'this is a post with foo and bar')
+        automation.trigger!('post' => post)
+      }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
In the future I would like to have a custom error panel in automation, but for now it's fine to just do nothing in this case.