### PR TITLE
FIX: ensures we don't crash if url is given

### DIFF
--- a/app/lib/discourse_automation/scripts/zapier_webhook.rb
+++ b/app/lib/discourse_automation/scripts/zapier_webhook.rb
@@ -12,7 +12,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::ZAPIER_WEBH
   script do |context, fields|
     webhook_url = fields.dig('webhook_url', 'value')
 
-    unless webhook_url.start_with?("https://hooks.zapier.com/hooks/catch/")
+    unless webhook_url&.start_with?("https://hooks.zapier.com/hooks/catch/")
       Rails.logger.warn "[discourse-automation] #{webhook_url} is not a valid Zapier webhook URL, expecting an URL starting with https://hooks.zapier.com/hooks/catch/"
       next
     end


### PR DESCRIPTION
Technically this shouldn't be possible while using the app, but this can be hit in tests for example.