### PR TITLE
DEV: Use JSON.parse instead of JSON.load

### DIFF
--- a/app/lib/discourse_automation/scripts/auto_responder.rb
+++ b/app/lib/discourse_automation/scripts/auto_responder.rb
@@ -21,7 +21,10 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_RESPON
     post = context['post']
 
     answers = Set.new
-    tuples = JSON.load(fields.dig('word_answer_list', 'value'))
+    json = fields.dig('word_answer_list', 'value')
+    next if json.blank?
+
+    tuples = JSON.parse(json)
 
     next if tuples.blank?
 

--- a/spec/jobs/stalled_topic_tracker_spec.rb
+++ b/spec/jobs/stalled_topic_tracker_spec.rb
@@ -26,7 +26,7 @@ describe Jobs::StalledTopicTracker do
       create_post(topic: topic_1, user: user_1, created_at: 1.month.ago)
       create_post(topic: topic_1, user: user_1, created_at: 1.month.ago)
 
-      output = JSON.load(capture_stdout do
+      output = JSON.parse(capture_stdout do
         Jobs::StalledTopicTracker.new.execute
       end)
 

--- a/spec/requests/discourse_automation_automations_spec.rb
+++ b/spec/requests/discourse_automation_automations_spec.rb
@@ -21,7 +21,7 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
           before { sign_in(Fabricate(:admin)) }
 
           it 'triggers the automation' do
-            output = JSON.load(capture_stdout do
+            output = JSON.parse(capture_stdout do
               post "/automations/#{automation.id}/trigger.json"
             end)
 
@@ -75,7 +75,7 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
       end
 
       it 'passes the params' do
-        output = JSON.load(capture_stdout do
+        output = JSON.parse(capture_stdout do
           post "/automations/#{automation.id}/trigger.json", { params: { foo: '1', bar: '2' } }
         end)
 

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -15,14 +15,14 @@ describe 'PostCreatedEdited' do
     it 'fires the trigger' do
       post = nil
 
-      output = JSON.load(capture_stdout do
+      output = JSON.parse(capture_stdout do
         post = PostCreator.create(user, basic_topic_params)
       end)
 
       expect(output['kind']).to eq('post_created_edited')
       expect(output['action']).to eq('create')
 
-      output = JSON.load(capture_stdout do
+      output = JSON.parse(capture_stdout do
         post.revise(post.user, raw: 'this is another cool topic')
       end)
 
@@ -37,7 +37,7 @@ describe 'PostCreatedEdited' do
 
       context 'trust level is allowed' do
         it 'fires the trigger' do
-          output = JSON.load(capture_stdout do
+          output = JSON.parse(capture_stdout do
             user.trust_level = TrustLevel[0]
             PostCreator.create(user, basic_topic_params)
           end)
@@ -48,12 +48,12 @@ describe 'PostCreatedEdited' do
 
       context 'trust level is not allowed' do
         it 'doesn’t fire the trigger' do
-          output = JSON.load(capture_stdout do
+          output = capture_stdout do
             user.trust_level = TrustLevel[1]
             PostCreator.create(user, basic_topic_params)
-          end)
+          end
 
-          expect(output).to be_nil
+          expect(output).to be_blank
         end
       end
     end
@@ -65,7 +65,7 @@ describe 'PostCreatedEdited' do
 
       context 'category is allowed' do
         it 'fires the trigger' do
-          output = JSON.load(capture_stdout do
+          output = JSON.parse(capture_stdout do
             PostCreator.create(user, basic_topic_params.merge({ category: Category.first.id }))
           end)
 
@@ -77,11 +77,11 @@ describe 'PostCreatedEdited' do
         fab!(:category) { Fabricate(:category) }
 
         it 'doesn’t fire the trigger' do
-          output = JSON.load(capture_stdout do
+          output = capture_stdout do
             PostCreator.create(user, basic_topic_params.merge({ category: category.id }))
-          end)
+          end
 
-          expect(output).to be_nil
+          expect(output).to be_blank
         end
       end
     end


### PR DESCRIPTION
Our Rubocop rules ban `JSON.load` because it's unsafe when used with untrusted data so we need to switch to `JSON.parse`. Minor refactoring is needed because `JSON.load` doesn't raise when it's given an empty string or nil, but `JSON.parse` does.