### PR TITLE
FEATURE: allows to insert reports using placeholders syntax

### DIFF
--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -150,7 +150,7 @@ module DiscourseAutomation
         map[:site_title] = SiteSetting.title
 
         regex = /%%REPORT=(.*?)%%/
-        input = input.gsub(/%%REPORT=(.*?)%%/) do |pattern|
+        input = input.gsub(regex) do |pattern|
           match = pattern.match(regex)
           if match
             fetch_report(match[1].downcase)

--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -134,14 +134,10 @@ module DiscourseAutomation
 
         ordered_columns = report.labels.map { |l| l[:property] }
 
-        table = "\n"
-        table += '|' + report.labels.map { |l| l[:title] }.join('|') + "|\n"
-        table += '|' + report.labels.count.times.map { '-' }.join('|') + "|\n"
-        report.data.each do |data|
-          table += '|'
-          table += ordered_columns.map { |col| data[col] }.join('|')
-          table += "|\n"
-        end
+        table = +"\n"
+        table << '|' + report.labels.map { |l| l[:title] }.join('|') + "|\n"
+        table << '|' + report.labels.count.times.map { '-' }.join('|') + "|\n"
+        report.data.each { |data| table << "|#{ordered_columns.map { |col| data[col] }.join('|')}|\n" }
         table
       end
 

--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -145,13 +145,13 @@ module DiscourseAutomation
         table
       end
 
+      REPORT_REGEX = /%%REPORT=(.*?)%%/
       def self.apply_placeholders(input, map)
         input = input.dup
         map[:site_title] = SiteSetting.title
 
-        regex = /%%REPORT=(.*?)%%/
-        input = input.gsub(regex) do |pattern|
-          match = pattern.match(regex)
+        input = input.gsub(REPORT_REGEX) do |pattern|
+          match = pattern.match(REPORT_REGEX)
           if match
             fetch_report(match[1].downcase)
           end

--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -128,7 +128,7 @@ module DiscourseAutomation
       def self.fetch_report(name, args = {})
         report = Report.find(name, args)
 
-        return nil if !report
+        return if !report
 
         return if !report.modes.include?(:table)
 

--- a/app/serializers/discourse_automation/automation_serializer.rb
+++ b/app/serializers/discourse_automation/automation_serializer.rb
@@ -25,7 +25,7 @@ module DiscourseAutomation
     end
 
     def placeholders
-      (scriptable.placeholders || []) + (triggerable.placeholders || [])
+      (scriptable.placeholders || []) + (triggerable.placeholders || []) + ["report=report_name"]
     end
 
     def script

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -120,13 +120,42 @@ describe DiscourseAutomation::Scriptable do
     end
   end
 
-  context '.utils' do
+  describe '.utils' do
+    describe '.fetch_report' do
+      context 'the report doesn’t exist' do
+        it 'does nothing' do
+          expect(automation.scriptable.utils.fetch_report(:foo)).to eq(nil)
+        end
+      end
+
+      context 'the report exists' do
+        fab!(:like_1) { Fabricate(:like, user: Fabricate(:user)) }
+        fab!(:like_2) { Fabricate(:like, user: Fabricate(:user)) }
+
+        it 'returns the data' do
+          expect(automation.scriptable.utils.fetch_report(:likes)).to eq("\n|Day|Count|\n|-|-|\n|2022-02-25|2|\n")
+        end
+      end
+    end
+
     describe '.apply_placeholders' do
       it 'replaces the given string by placeholders' do
         input = 'hello %%COOL_CAT%%'
         map = { cool_cat: 'siberian cat' }
         output = automation.scriptable.utils.apply_placeholders(input, map)
         expect(output).to eq('hello siberian cat')
+      end
+
+      context 'using the REPORT key' do
+        fab!(:like_1) { Fabricate(:like, user: Fabricate(:user)) }
+        fab!(:like_2) { Fabricate(:like, user: Fabricate(:user)) }
+
+        it 'replaces REPORT key' do
+          input = 'hello %%REPORT=likes%%'
+
+          output = automation.scriptable.utils.apply_placeholders(input, {})
+          expect(output).to eq("hello \n|Day|Count|\n|-|-|\n|2022-02-25|2|\n")
+        end
       end
     end
 


### PR DESCRIPTION
In any field allowing placeholders like PM body:

```
This is the last likes report:

%%REPORT=likes%%
```

Will be replaced by:

```
This is the last likes report:

|Day|Count|
|-|-|
|2022-02-25|2|
```

For now it doesn’t support specific args and will just use defaults.