### PR TITLE
FIX: ensures we don't mutate automation object

### DIFF
--- a/app/controllers/admin/discourse_automation/admin_discourse_automation_triggerables_controller.rb
+++ b/app/controllers/admin/discourse_automation/admin_discourse_automation_triggerables_controller.rb
@@ -11,7 +11,7 @@ module DiscourseAutomation
         triggerables = DiscourseAutomation::Triggerable.all
       end
 
-      triggerables.map! do |s|
+      triggerables = triggerables.map do |s|
         id = s.to_s.gsub(/^__triggerable_/, '')
         {
           id: id,


### PR DESCRIPTION
This would cause on specific circumstance `automation.scriptable.triggerables` to be altered and return an array of hash for next run instead of an array of strings.