### PR TITLE
DEV: Remove duplicate route

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -152,10 +152,6 @@ after_initialize do
       delete '/user-global-notices/:id' => 'user_global_notices#destroy'
     end
 
-    scope format: :json, constraints: AdminConstraint.new do
-      post '/automations/:id/trigger' => 'automations#trigger'
-    end
-
     scope '/admin/plugins/discourse-automation', as: 'admin_discourse_automation', constraints: AdminConstraint.new do
       scope format: false do
         get '/' => 'admin_discourse_automation#index'


### PR DESCRIPTION
The same exact route is declared a few lines (line 147-149) earlier so I think this was added erroneously and can be removed.