### PR TITLE
FEATURE: adds a user_granted_badge trigger

### DIFF
--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -152,7 +152,7 @@ module DiscourseAutomation
         input = apply_report_placeholder(input)
 
         map.each do |key, value|
-          input = input.gsub("%%#{key.upcase}%%", value)
+          input = input.gsub("%%#{key.upcase}%%", value.to_s)
         end
 
         input

--- a/app/lib/discourse_automation/scripts/send_pms.rb
+++ b/app/lib/discourse_automation/scripts/send_pms.rb
@@ -12,7 +12,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::SEND_PMS) d
   field :receiver, component: :user, triggerable: :recurring
   field :sendable_pms, component: :pms, accepts_placeholders: true, required: true
 
-  triggerables %i[user_added_to_group stalled_wiki recurring user_promoted api_call]
+  triggerables %i[user_badge_granted user_added_to_group stalled_wiki recurring user_promoted api_call]
 
   script do |context, fields, automation|
     sender_username = fields.dig('sender', 'value') || Discourse.system_user.username

--- a/app/lib/discourse_automation/scripts/zapier_webhook.rb
+++ b/app/lib/discourse_automation/scripts/zapier_webhook.rb
@@ -7,7 +7,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::ZAPIER_WEBH
 
   version 1
 
-  triggerables [:user_promoted, :user_added_to_group]
+  triggerables [:user_promoted, :user_added_to_group, :user_badge_granted]
 
   script do |context, fields|
     webhook_url = fields.dig('webhook_url', 'value')

--- a/app/lib/discourse_automation/triggers/user_badge_granted.rb
+++ b/app/lib/discourse_automation/triggers/user_badge_granted.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Triggerable::USER_BADGE_GRANTED = 'user_badge_granted'
+
+DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED) do
+  field :badge, component: :choices, extra: { content: Badge.all.map { |b| { id: b.id, translated_name: b.name } } }, required: true
+  field :only_first_grant, component: :boolean
+  placeholder :badge_name
+  placeholder :grant_count
+end

--- a/app/services/discourse_automation/user_badge_granted_handler.rb
+++ b/app/services/discourse_automation/user_badge_granted_handler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module DiscourseAutomation
+  class UserBadgeGrantedHandler
+    def self.handle(automation, badge_id, user_id)
+      tracked_badge_id = automation.trigger_field('badge')['value']
+      if tracked_badge_id != badge_id
+        return
+      end
+
+      badge = Badge.find(badge_id)
+
+      only_first_grant = automation.trigger_field('only_first_grant')['value']
+      if only_first_grant && badge.grant_count > 1
+        return
+      end
+
+      user = User.find(user_id)
+
+      automation.trigger!(
+        'kind' => DiscourseAutomation::Triggerable::USER_BADGE_GRANTED,
+        'usernames' => [user.username],
+        'badge' => badge,
+        'placeholders' => {
+          'badge_name' => badge.name,
+          'grant_count' => badge.grant_count
+        }
+      )
+    end
+  end
+end

--- a/assets/javascripts/discourse/components/fields/da-choices-field.js
+++ b/assets/javascripts/discourse/components/fields/da-choices-field.js
@@ -8,7 +8,7 @@ export default class ChoicesField extends BaseField {
     return (this.field.extra.content || []).map((r) => {
       return {
         id: r.id,
-        name: I18n.t(r.name),
+        name: r.translated_name || I18n.t(r.name),
       };
     });
   }

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -48,6 +48,12 @@ en:
           label: Text
       triggerables:
         not_found: Couldn’t find trigger `%{trigger}` for automation `%{automation}`, ensure the associated plugin is installed
+        user_badge_granted:
+          fields:
+            badge:
+              label: Badge
+            only_first_grant:
+              label: Only on first grant
         stalled_topic:
           durations:
             PT1H: "One hour"

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,6 +8,9 @@ en:
         invalid_field: Field’s component `%{component}` is not usable on `%{target}:%{target_name}.`
         invalid_metadata: Data for `%{field}` is invalid or component `%{component}` is unknown.
     triggerables:
+      user_badge_granted:
+        title: User badge granted
+        doc: Triggers an automation when a user is granted a badge.
       stalled_topic:
         title: Stalled topic
         doc: Triggers an automation when the topic has not received a new reply from topic owner for a specified period of time. It is recommended to scope this trigger to a tag/category as the number of topics impacted can be very high. As a safety measure, the number of impacted topics is capped at 250.

--- a/plugin.rb
+++ b/plugin.rb
@@ -80,9 +80,11 @@ require File.expand_path('../app/core_ext/plugin_instance', __FILE__)
 after_initialize do
   [
     '../app/queries/stalled_topic_finder',
+    '../app/services/discourse_automation/user_badge_granted_handler',
     '../app/lib/discourse_automation/triggers/stalled_wiki',
     '../app/lib/discourse_automation/triggers/stalled_topic',
     '../app/lib/discourse_automation/triggers/user_added_to_group',
+    '../app/lib/discourse_automation/triggers/user_badge_granted',
     '../app/lib/discourse_automation/triggers/point_in_time',
     '../app/lib/discourse_automation/triggers/post_created_edited',
     '../app/lib/discourse_automation/triggers/topic',
@@ -191,6 +193,15 @@ after_initialize do
         )
       end
     end
+  end
+
+  on(:user_badge_granted) do |badge_id, user_id|
+    name = DiscourseAutomation::Triggerable::USER_BADGE_GRANTED
+    DiscourseAutomation::Automation
+      .where(trigger: name, enabled: true)
+      .find_each do |automation|
+        DiscourseAutomation::UserBadgeGrantedHandler.handle(automation, badge_id, user_id)
+      end
   end
 
   on(:user_promoted) do |payload|

--- a/spec/services/user_badge_granted_spec.rb
+++ b/spec/services/user_badge_granted_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe DiscourseAutomation::UserBadgeGrantedHandler do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:automation) {
+    Fabricate(
+      :automation,
+      trigger: DiscourseAutomation::Triggerable::USER_BADGE_GRANTED
+    )
+  }
+
+  before do
+    SiteSetting.discourse_automation_enabled = true
+  end
+
+  context 'badge is not tracked' do
+    fab!(:tracked_badge) { Fabricate(:badge) }
+
+    it 'doesn’t trigger the automation' do
+      output = capture_stdout do
+        described_class.handle(automation, tracked_badge.id, user.id)
+      end
+      expect(output).to be_blank
+    end
+  end
+
+  context 'badge is tracked' do
+    fab!(:tracked_badge) { Fabricate(:badge) }
+
+    before do
+      automation.upsert_field!('badge', 'choices', { value: tracked_badge.id }, target: 'trigger')
+    end
+
+    context 'only trigger on first grant' do
+      before do
+        automation.upsert_field!('only_first_grant', 'boolean', { value: true }, target: 'trigger')
+      end
+
+      context 'badge has been granted already' do
+        fab!(:tracked_badge) { Fabricate(:badge, grant_count: 2) }
+
+        it 'doesn’t trigger the automation' do
+          output = capture_stdout do
+            described_class.handle(automation, tracked_badge.id, user.id)
+          end
+          expect(output).to be_blank
+        end
+      end
+
+      context 'badge has not been granted already' do
+        fab!(:tracked_badge) { Fabricate(:badge, grant_count: 1) }
+
+        it 'triggers the automation' do
+          output = JSON.parse(capture_stdout do
+            described_class.handle(automation, tracked_badge.id, user.id)
+          end)
+          expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
+        end
+      end
+
+      context 'user doesn’t exist' do
+        fab!(:tracked_badge) { Fabricate(:badge, grant_count: 1) }
+
+        it 'raises an error' do
+          expect {
+            described_class.handle(automation, tracked_badge.id, -999)
+          }.to raise_error(ActiveRecord::RecordNotFound, /'id'=-999/)
+        end
+      end
+    end
+
+    it 'triggers the automation' do
+      output = JSON.parse(capture_stdout do
+        described_class.handle(automation, tracked_badge.id, user.id)
+      end)
+
+      expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
+      expect(output['usernames']).to eq([user.username])
+      expect(output['placeholders']).to eq('badge_name' => tracked_badge.name, 'grant_count' => tracked_badge.grant_count)
+      expect(output['badge']['id']).to eq(tracked_badge.id)
+    end
+  end
+end

--- a/spec/triggers/user_badge_granted_spec.rb
+++ b/spec/triggers/user_badge_granted_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe 'UserBadgeGranted' do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:tracked_badge) { Fabricate(:badge) }
+  fab!(:automation) {
+    Fabricate(
+      :automation,
+      trigger: DiscourseAutomation::Triggerable::USER_BADGE_GRANTED
+    )
+  }
+
+  before do
+    SiteSetting.discourse_automation_enabled = true
+    automation.upsert_field!('badge', 'choices', { value: tracked_badge.id }, target: 'trigger')
+  end
+
+  context 'a badge is granted' do
+    it 'fires the trigger' do
+      output = JSON.parse(capture_stdout do
+        BadgeGranter.grant(tracked_badge, user)
+      end)
+
+      expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
+    end
+  end
+end


### PR DESCRIPTION
This trigger needs a `badge` as required field and accepts an optional `only_on_first_grant` field. ATM it’s usable for: `send_pms` and `zapier_webhook` scripts.