### PR TITLE
FIX: remove `INTERVAL` param from `RRule` in weekday calculation.

### DIFF
--- a/app/lib/discourse_automation/triggers/recurring.rb
+++ b/app/lib/discourse_automation/triggers/recurring.rb
@@ -47,10 +47,11 @@ def setup_pending_automation(automation, fields)
       .between(Time.now, interval_end.months.from_now)
       .first
   when 'weekday'
+    max_weekends = (interval_end.to_f / 5).ceil
     next_trigger_date = RRule::Rule
-      .new("FREQ=DAILY;INTERVAL=#{interval};BYDAY=MO,TU,WE,TH,FR", dtstart: start_date)
-      .between(Time.now.end_of_day, (interval_end + 1).days.from_now)
-      .first
+      .new("FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR", dtstart: start_date)
+      .between(Time.now.end_of_day, max_weekends.weeks.from_now)
+      .drop(interval - 1).first
   when 'week'
     next_trigger_date = RRule::Rule
       .new("FREQ=WEEKLY;INTERVAL=#{interval};BYDAY=#{byday}", dtstart: start_date)

--- a/spec/triggers/recurring_spec.rb
+++ b/spec/triggers/recurring_spec.rb
@@ -102,16 +102,28 @@ describe 'Recurring' do
     end
 
     context 'every_weekday' do
-      before do
-        upsert_period_field!(1, 'weekday')
-      end
-
       it 'creates the next iteration one day after without Saturday/Sunday' do
+        upsert_period_field!(1, 'weekday')
         automation.trigger!
 
         pending_automation = DiscourseAutomation::PendingAutomation.last
         start_date = Time.parse(automation.trigger_field('start_date')['value'])
         expect(pending_automation.execute_at).to be_within_one_minute_of(start_date + 3.day)
+      end
+
+      it 'creates the next iteration three days after without Saturday/Sunday' do
+        now = DateTime.parse("2022-05-19").end_of_day
+        start_date = now - 1.hour
+        freeze_time now
+
+        automation.pending_automations.destroy_all
+        automation.upsert_field!('start_date', 'date_time', { value: start_date }, target: 'trigger')
+        upsert_period_field!(3, 'weekday')
+        
+        automation.trigger!
+
+        pending_automation = automation.pending_automations.last
+        expect(pending_automation.execute_at).to be_within_one_minute_of(start_date + 5.days)
       end
     end
 

--- a/spec/triggers/recurring_spec.rb
+++ b/spec/triggers/recurring_spec.rb
@@ -119,7 +119,7 @@ describe 'Recurring' do
         automation.pending_automations.destroy_all
         automation.upsert_field!('start_date', 'date_time', { value: start_date }, target: 'trigger')
         upsert_period_field!(3, 'weekday')
-        
+
         automation.trigger!
 
         pending_automation = automation.pending_automations.last


### PR DESCRIPTION
The `INTERVAL` param is working differently in `RRule` when we use it with `BYDAY=MO,TU,WE,TH,FR` param to find out weekdays. So we removed it and using a different calculation to find the weekday.