### PR TITLE
DEV: Remove 'htmlSafe' string prototype extensions

### DIFF
--- a/assets/javascripts/discourse/helpers/format-enabled-automation.js
+++ b/assets/javascripts/discourse/helpers/format-enabled-automation.js
@@ -1,16 +1,21 @@
 import { iconHTML } from "discourse-common/lib/icon-library";
 import { registerUnbound } from "discourse-common/lib/helpers";
+import { htmlSafe } from "@ember/template";
 
 registerUnbound("format-enabled-automation", function (enabled, trigger) {
   if (enabled && trigger.id) {
-    return iconHTML("check", {
-      class: "enabled-automation",
-      title: "discourse_automation.models.automation.enabled.label",
-    }).htmlSafe();
+    return htmlSafe(
+      iconHTML("check", {
+        class: "enabled-automation",
+        title: "discourse_automation.models.automation.enabled.label",
+      })
+    );
   } else {
-    return iconHTML("times", {
-      class: "disabled-automation",
-      title: "discourse_automation.models.automation.disabled.label",
-    }).htmlSafe();
+    return htmlSafe(
+      iconHTML("times", {
+        class: "disabled-automation",
+        title: "discourse_automation.models.automation.disabled.label",
+      })
+    );
   }
 });


### PR DESCRIPTION
## Ember Upgrade

Context: https://deprecations.emberjs.com/v3.x/#toc_ember-string-prototype_extensions