### PR TITLE
FIX: automation was checking grant_count incorrectly

### DIFF
--- a/app/services/discourse_automation/user_badge_granted_handler.rb
+++ b/app/services/discourse_automation/user_badge_granted_handler.rb
@@ -11,7 +11,7 @@ module DiscourseAutomation
       badge = Badge.find(badge_id)
 
       only_first_grant = automation.trigger_field('only_first_grant')['value']
-      if only_first_grant && badge.grant_count > 1
+      if only_first_grant && UserBadge.where(user_id: user_id, badge_id: badge_id).count >= 1
         return
       end
 

--- a/spec/services/user_badge_granted_spec.rb
+++ b/spec/services/user_badge_granted_spec.rb
@@ -39,7 +39,11 @@ describe DiscourseAutomation::UserBadgeGrantedHandler do
       end
 
       context 'badge has been granted already' do
-        fab!(:tracked_badge) { Fabricate(:badge, grant_count: 2) }
+        fab!(:tracked_badge) { Fabricate(:badge) }
+
+        before do
+          BadgeGranter.grant(tracked_badge, user)
+        end
 
         it 'doesn’t trigger the automation' do
           output = capture_stdout do


### PR DESCRIPTION
grant_count is a global counter for grants of this badge across all users, not the count for a specific user. This commit now correctly checks if the badge has been awarded more than once.