### PR TITLE
FIX: triggers on first badge

### DIFF
--- a/app/services/discourse_automation/user_badge_granted_handler.rb
+++ b/app/services/discourse_automation/user_badge_granted_handler.rb
@@ -11,7 +11,8 @@ module DiscourseAutomation
       badge = Badge.find(badge_id)
 
       only_first_grant = automation.trigger_field('only_first_grant')['value']
-      if only_first_grant && UserBadge.where(user_id: user_id, badge_id: badge_id).count >= 1
+
+      if only_first_grant && UserBadge.where(user_id: user_id, badge_id: badge_id).count > 1
         return
       end
 


### PR DESCRIPTION
Tests were erroneous as multiple grant was silently preventing multiple badges to be created