### PR TITLE
Add add_user_to_group_through_custom_field script

### DIFF
--- a/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
+++ b/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Scriptable::ADD_USER_TO_GROUP_THROUGH_CUSTOM_FIELD = 'add_user_to_group_through_custom_field'
+
+# This script takes the name of a User Custom Field containing a group name.
+# On each run, it ensures that each user belongs to the group name given by that UCF.
+#
+# In other words, it designates a certain User Custom Field to act as
+# a "pointer" to a group that the user should belong to, and adds users as needed.
+
+DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::ADD_USER_TO_GROUP_THROUGH_CUSTOM_FIELD) do
+  field :custom_field_name, component: :text, required: true
+
+  version 1
+
+  triggerables %i[recurring]
+
+  script do |trigger, fields|
+    custom_field_name = fields.dig('custom_field_name', 'value')
+
+    query = DB.query(<<-SQL, custom_field_name)
+      SELECT u.id as user_id, g.id as group_id
+      FROM users u
+      JOIN user_custom_fields ucf
+        ON u.id = ucf.user_id
+        AND ucf.name = ?
+      JOIN groups g
+        on g.name = ucf.value
+      FULL OUTER JOIN group_users gu
+        ON gu.user_id = u.id
+        AND gu.group_id = (select id from groups where name = ucf.value)
+      WHERE gu.id is null
+        AND u.active = true
+      ORDER BY 1, 2
+    SQL
+
+    groups_by_id = {}
+
+    User.where(id: query.map(&:user_id)).order(:id).zip(query) do |user, query_row|
+      group_id = query_row.group_id
+      group = groups_by_id[group_id] ||= Group.find(group_id)
+
+      group.add(user)
+      GroupActionLogger.new(Discourse.system_user, group).log_add_user_to_group(user)
+    end
+  end
+end

--- a/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
+++ b/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
@@ -28,7 +28,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::ADD_USER_TO
         on g.name = ucf.value
       FULL OUTER JOIN group_users gu
         ON gu.user_id = u.id
-        AND gu.group_id = (select id from groups where name = ucf.value)
+        AND gu.group_id = g.id
       WHERE gu.id is null
         AND u.active = true
       ORDER BY 1, 2

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -243,6 +243,11 @@ en:
             user:
               label: User
               description: "The user closing the topic (default: system)"
+        add_user_to_group_through_custom_field:
+          fields:
+            custom_field_name:
+              label: 'User Custom Field name'
+
       models:
         script:
           name:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -102,3 +102,5 @@ en:
         summary: Check document
         details: "Perform check on document: "
         button_text: Done
+      add_user_to_group_through_custom_field:
+        title: 'Add user to group through User Custom Field'

--- a/plugin.rb
+++ b/plugin.rb
@@ -182,6 +182,7 @@ after_initialize do
     '../app/lib/discourse_automation/scripts/topic_required_words',
     '../app/lib/discourse_automation/scripts/flag_post_on_words',
     '../app/lib/discourse_automation/scripts/zapier_webhook',
+    '../app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field',
   ].each { |path| require File.expand_path(path, __FILE__) }
 
   module ::DiscourseAutomation

--- a/spec/scripts/add_user_to_group_through_custom_field_spec.rb
+++ b/spec/scripts/add_user_to_group_through_custom_field_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe 'AddUserTogroupThroughCustomField' do
+  fab!(:user1) { Fabricate(:user) }
+  fab!(:user2) { Fabricate(:user) }
+  fab!(:group) { Fabricate(:group) }
+
+  fab!(:automation) do
+    Fabricate(
+      :automation,
+      script: DiscourseAutomation::Scriptable::ADD_USER_TO_GROUP_THROUGH_CUSTOM_FIELD
+    )
+  end
+
+  before do
+    automation.upsert_field!('custom_field_name', 'text', { value: 'groupity_group' }, target: 'script')
+  end
+
+  context 'with no matching user custom fields' do
+    it 'works' do
+      expect(user1.groups).to be_empty
+      expect(user2.groups).to be_empty
+
+      automation.trigger!
+
+      user1.reload
+      user2.reload
+
+      expect(user1.groups).to be_empty
+      expect(user2.groups).to be_empty
+    end
+  end
+
+  context 'with one matching user' do
+    before do
+      UserCustomField.create!(user_id: user1.id, name: 'groupity_group', value: group.name)
+    end
+
+    it 'works' do
+      expect(user1.groups).to be_empty
+      expect(user2.groups).to be_empty
+
+      automation.trigger!
+
+      user1.reload
+      user2.reload
+
+      expect(user1.groups.count).to eq(1)
+      expect(user1.groups.first.name).to eq(group.name)
+
+      expect(user2.groups).to be_empty
+    end
+  end
+
+  context 'when group is already present' do
+    before do
+      group.add(user1)
+    end
+
+    it 'works' do
+      expect(user1.groups.count).to eq(1)
+      expect(user2.groups).to be_empty
+
+      automation.trigger!
+
+      user1.reload
+      user2.reload
+
+      expect(user1.groups.count).to eq(1)
+      expect(user1.groups.first.name).to eq(group.name)
+
+      expect(user2.groups).to be_empty
+    end
+  end
+
+end


### PR DESCRIPTION
The new `add_user_to_group_through_custom_field` script accepts a Recurring trigger, and takes the name of a User Custom Field containing a group name.
On each run, it ensures that each user belongs to the group name given by their UCF.

In other words, it designates a certain User Custom Field to act as a "pointer" to a group that the user should belong to, and adds users to that group as needed.