### PR TITLE
add_user_to_group_through_custom_field_spec: use group.full_name

### DIFF
--- a/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
+++ b/app/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
@@ -3,7 +3,7 @@
 DiscourseAutomation::Scriptable::ADD_USER_TO_GROUP_THROUGH_CUSTOM_FIELD = 'add_user_to_group_through_custom_field'
 
 # This script takes the name of a User Custom Field containing a group name.
-# On each run, it ensures that each user belongs to the group name given by that UCF.
+# On each run, it ensures that each user belongs to the group name given by that UCF (NOTE: group full_name, not name).
 #
 # In other words, it designates a certain User Custom Field to act as
 # a "pointer" to a group that the user should belong to, and adds users as needed.
@@ -25,7 +25,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::ADD_USER_TO
         ON u.id = ucf.user_id
         AND ucf.name = ?
       JOIN groups g
-        on g.name = ucf.value
+        on g.full_name ilike ucf.value
       FULL OUTER JOIN group_users gu
         ON gu.user_id = u.id
         AND gu.group_id = g.id

--- a/spec/scripts/add_user_to_group_through_custom_field_spec.rb
+++ b/spec/scripts/add_user_to_group_through_custom_field_spec.rb
@@ -5,7 +5,7 @@ require_relative '../discourse_automation_helper'
 describe 'AddUserTogroupThroughCustomField' do
   fab!(:user1) { Fabricate(:user) }
   fab!(:user2) { Fabricate(:user) }
-  fab!(:group) { Fabricate(:group) }
+  fab!(:group) { Fabricate(:group, full_name: 'Groupity Group') }
 
   fab!(:automation) do
     Fabricate(
@@ -35,7 +35,7 @@ describe 'AddUserTogroupThroughCustomField' do
 
   context 'with one matching user' do
     before do
-      UserCustomField.create!(user_id: user1.id, name: 'groupity_group', value: group.name)
+      UserCustomField.create!(user_id: user1.id, name: 'groupity_group', value: group.full_name)
     end
 
     it 'works' do
@@ -48,7 +48,7 @@ describe 'AddUserTogroupThroughCustomField' do
       user2.reload
 
       expect(user1.groups.count).to eq(1)
-      expect(user1.groups.first.name).to eq(group.name)
+      expect(user1.groups.first.full_name).to eq(group.full_name)
 
       expect(user2.groups).to be_empty
     end
@@ -69,7 +69,7 @@ describe 'AddUserTogroupThroughCustomField' do
       user2.reload
 
       expect(user1.groups.count).to eq(1)
-      expect(user1.groups.first.name).to eq(group.name)
+      expect(user1.groups.first.full_name).to eq(group.full_name)
 
       expect(user2.groups).to be_empty
     end


### PR DESCRIPTION
Match on group.full_name rather than group.name, so that the UCF can use user friendly values (ie. `United States`) rather than valid group names (ie. `UnitedStates`).