### PR TITLE
FEATURE: allow tag filter on after post cooked

### DIFF
--- a/app/lib/discourse_automation/triggers/after_post_cook.rb
+++ b/app/lib/discourse_automation/triggers/after_post_cook.rb
@@ -4,5 +4,6 @@ DiscourseAutomation::Triggerable::AFTER_POST_COOK = 'after_post_cook'
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::AFTER_POST_COOK) do
   field :restricted_category, component: :category
+  field :restricted_tags, component: :tags
   field :valid_trust_levels, component: :'trust-levels'
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -156,6 +156,9 @@ en:
             restricted_category:
               label: Category
               description: Optional, allows to limit trigger execution to this category
+            restricted_tags:
+              label: Tags
+              description: Optional, allows to limit trigger execution to any of these tags
       scriptables:
         not_found: Couldn’t find script `%{script}` for automation `%{automation}`, ensure the associated plugin is installed
         zapier_webhook:

--- a/plugin.rb
+++ b/plugin.rb
@@ -92,6 +92,7 @@ def handle_after_post_cook(post, cooked)
 
         post.topic.tags.each do |tag|
           found ||= tag_names.include?(tag.name)
+          break if found
         end
 
         next if !found

--- a/plugin.rb
+++ b/plugin.rb
@@ -85,6 +85,18 @@ def handle_after_post_cook(post, cooked)
         next if restricted_category['value'] != category_id
       end
 
+      restricted_tags = automation.trigger_field('restricted_tags')
+      if tag_names = restricted_tags['value']
+        found = false
+        next if !post.topic
+
+        post.topic.tags.each do |tag|
+          found ||= tag_names.include?(tag.name)
+        end
+
+        next if !found
+      end
+
       if new_cooked = automation.trigger!('kind' => name, 'post' => post, 'cooked' => cooked)
         cooked = new_cooked
       end

--- a/spec/discourse_automation_helper.rb
+++ b/spec/discourse_automation_helper.rb
@@ -8,7 +8,6 @@ end
 
 module DiscourseAutomation::CapturedContext
   def self.add(context)
-    @contexts ||= []
     @contexts << context
   end
 

--- a/spec/discourse_automation_helper.rb
+++ b/spec/discourse_automation_helper.rb
@@ -2,8 +2,31 @@
 
 require 'rails_helper'
 
+def capture_contexts(&blk)
+  DiscourseAutomation::CapturedContext.capture(&blk)
+end
+
+module DiscourseAutomation::CapturedContext
+  def self.add(context)
+    @contexts ||= []
+    @contexts << context
+  end
+
+  def self.capture
+    raise StandardError, "Nested capture is not supported" if @capturing
+    raise StandardError, "Expecting a block" if !block_given?
+    @capturing = true
+    @contexts = []
+    yield
+    @contexts
+  ensure
+    @capturing = false
+  end
+
+end
+
 DiscourseAutomation::Scriptable.add('something_about_us') do
-  script { |context| puts context.to_json }
+  script { |context| DiscourseAutomation::CapturedContext.add(context); nil }
   triggerables [DiscourseAutomation::Triggerable::API_CALL]
 end
 

--- a/spec/jobs/stalled_topic_tracker_spec.rb
+++ b/spec/jobs/stalled_topic_tracker_spec.rb
@@ -26,12 +26,14 @@ describe Jobs::StalledTopicTracker do
       create_post(topic: topic_1, user: user_1, created_at: 1.month.ago)
       create_post(topic: topic_1, user: user_1, created_at: 1.month.ago)
 
-      output = JSON.parse(capture_stdout do
+      list = capture_contexts do
         Jobs::StalledTopicTracker.new.execute
-      end)
+      end
 
-      expect(output['kind']).to eq(DiscourseAutomation::Triggerable::STALLED_TOPIC)
-      expect(output['topic']['id']).to eq(topic_1.id)
+      expect(list.length).to eq(1)
+
+      expect(list.first['kind']).to eq(DiscourseAutomation::Triggerable::STALLED_TOPIC)
+      expect(list.first['topic']['id']).to eq(topic_1.id)
     end
   end
 end

--- a/spec/models/automation_spec.rb
+++ b/spec/models/automation_spec.rb
@@ -8,11 +8,11 @@ describe DiscourseAutomation::Automation do
       fab!(:automation) { Fabricate(:automation, enabled: false) }
 
       it 'doesn’t do anything' do
-        output = capture_stdout do
+        list = capture_contexts do
           automation.trigger!('Howdy!')
         end
 
-        expect(output).to_not include('Howdy!')
+        expect(list).to eq([])
       end
     end
 
@@ -20,11 +20,11 @@ describe DiscourseAutomation::Automation do
       fab!(:automation) { Fabricate(:automation, enabled: true) }
 
       it 'runs the script' do
-        output = capture_stdout do
+        list = capture_contexts do
           automation.trigger!('Howdy!')
         end
 
-        expect(output).to include('Howdy!')
+        expect(list).to eq(['Howdy!'])
       end
     end
   end

--- a/spec/requests/discourse_automation_automations_spec.rb
+++ b/spec/requests/discourse_automation_automations_spec.rb
@@ -21,11 +21,12 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
           before { sign_in(Fabricate(:admin)) }
 
           it 'triggers the automation' do
-            output = JSON.parse(capture_stdout do
+            list = capture_contexts do
               post "/automations/#{automation.id}/trigger.json"
-            end)
+            end
 
-            expect(output['kind']).to eq('api_call')
+            expect(list.length).to eq(1)
+            expect(list[0]['kind']).to eq('api_call')
           end
         end
 
@@ -55,14 +56,12 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
         let(:api_key) { Fabricate(:api_key, user: admin) }
 
         it 'works' do
-          capture_stdout do
-            post "/automations/#{automation.id}/trigger.json", {
-              params: { context: { foo: :bar } },
-              headers: {
-                HTTP_API_KEY: api_key.key
-              }
+          post "/automations/#{automation.id}/trigger.json", {
+            params: { context: { foo: :bar } },
+            headers: {
+              HTTP_API_KEY: api_key.key
             }
-          end
+          }
 
           expect(response.status).to eq(200)
         end
@@ -78,12 +77,16 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
       end
 
       it 'passes the params' do
-        output = JSON.parse(capture_stdout do
+        list = capture_contexts do
           post "/automations/#{automation.id}/trigger.json", { params: { foo: '1', bar: '2' } }
-        end)
+        end
 
-        expect(output['foo']).to eq('1')
-        expect(output['bar']).to eq('2')
+        expect(list.length).to eq(1)
+
+        first = list.first
+
+        expect(first['foo']).to eq('1')
+        expect(first['bar']).to eq('2')
         expect(response.status).to eq(200)
       end
     end

--- a/spec/services/user_badge_granted_spec.rb
+++ b/spec/services/user_badge_granted_spec.rb
@@ -18,10 +18,10 @@ describe DiscourseAutomation::UserBadgeGrantedHandler do
 
   context 'badge is not tracked' do
     it 'doesn’t trigger the automation' do
-      output = capture_stdout do
+      list = capture_contexts do
         described_class.handle(automation, tracked_badge.id, user.id)
       end
-      expect(output).to be_blank
+      expect(list).to be_blank
     end
   end
 
@@ -42,19 +42,21 @@ describe DiscourseAutomation::UserBadgeGrantedHandler do
         end
 
         it 'doesn’t trigger the automation' do
-          output = capture_stdout do
+          list = capture_contexts do
             described_class.handle(automation, tracked_badge.id, user.id)
           end
-          expect(output).to be_blank
+          expect(list).to be_blank
         end
       end
 
       context 'badge has not been granted already' do
         it 'triggers the automation' do
-          output = JSON.parse(capture_stdout do
+          list = capture_contexts do
             described_class.handle(automation, tracked_badge.id, user.id)
-          end)
-          expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
+          end
+
+          expect(list.length).to eq(1)
+          expect(list[0]['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
         end
       end
 
@@ -68,10 +70,12 @@ describe DiscourseAutomation::UserBadgeGrantedHandler do
     end
 
     it 'triggers the automation' do
-      output = JSON.parse(capture_stdout do
+      list = capture_contexts do
         described_class.handle(automation, tracked_badge.id, user.id)
-      end)
+      end
 
+      expect(list.length).to eq(1)
+      output = list[0]
       expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
       expect(output['usernames']).to eq([user.username])
       expect(output['placeholders']).to eq('badge_name' => tracked_badge.name, 'grant_count' => tracked_badge.grant_count)

--- a/spec/triggers/after_post_cook_spec.rb
+++ b/spec/triggers/after_post_cook_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../discourse_automation_helper'
+
+describe 'After post cooked' do
+  before do
+    SiteSetting.discourse_automation_enabled = true
+  end
+
+  fab!(:post) { Fabricate(:post) }
+  let(:topic) { post.topic }
+
+  fab!(:automation) do
+    Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::AFTER_POST_COOK)
+  end
+
+  context 'Filtered to a tag' do
+
+    let(:filtered_tag) {
+      Fabricate(:tag)
+    }
+
+    before do
+      automation.upsert_field!(
+        'restricted_tags',
+        'tags',
+        { value: ['random', filtered_tag.name] },
+        target: 'trigger'
+      )
+      automation.reload
+    end
+
+    it 'should not fire when tag is missing' do
+      captured = capture_contexts do
+        post.rebake!
+      end
+
+      expect(captured).to be_blank
+    end
+
+    it 'should fire when tag is present' do
+      topic.tags << filtered_tag
+      topic.save!
+
+      list = capture_contexts do
+        post.rebake!
+      end
+
+      expect(list.length).to eq(1)
+      expect(list[0]['kind']).to eq(DiscourseAutomation::Triggerable::AFTER_POST_COOK)
+    end
+
+  end
+end

--- a/spec/triggers/pm_created_spec.rb
+++ b/spec/triggers/pm_created_spec.rb
@@ -22,20 +22,21 @@ describe 'PMCreated' do
       fab!(:user2) { Fabricate(:user) }
 
       it "doesn't fire the trigger" do
-        output = capture_stdout do
+        list = capture_contexts do
           PostCreator.create(user, basic_topic_params.merge({ target_usernames: [user2.username] }))
         end
 
-        expect(output).to be_blank
+        expect(list).to be_blank
       end
     end
 
     it 'fires the trigger' do
-      output = JSON.parse(capture_stdout do
+      list = capture_contexts do
         PostCreator.create(user, basic_topic_params)
-      end)
+      end
 
-      expect(output['kind']).to eq('pm_created')
+      expect(list.length).to eq(1)
+      expect(list[0]['kind']).to eq('pm_created')
     end
 
     context 'trust_levels are restricted' do
@@ -45,25 +46,26 @@ describe 'PMCreated' do
 
       context 'trust level is allowed' do
         it 'fires the trigger' do
-          output = JSON.parse(capture_stdout do
+          list = capture_contexts do
             user.trust_level = TrustLevel[2]
             user.save!
             PostCreator.create(user, basic_topic_params)
-          end)
+          end
 
-          expect(output['kind']).to eq('pm_created')
+          expect(list.length).to eq(1)
+          expect(list[0]['kind']).to eq('pm_created')
         end
       end
 
       context 'trust level is not allowed' do
         it 'doesn’t fire the trigger' do
-          output = capture_stdout do
+          list = capture_contexts do
             user.trust_level = TrustLevel[1]
             user.save!
             PostCreator.create(user, basic_topic_params)
           end
 
-          expect(output).to be_blank
+          expect(list).to be_blank
         end
       end
     end
@@ -74,13 +76,13 @@ describe 'PMCreated' do
       end
 
       it 'doesn’t fire the trigger' do
-        output = capture_stdout do
+        list = capture_contexts do
           user.moderator = true
           user.save!
           PostCreator.create(user, basic_topic_params)
         end
 
-        expect(output).to be_blank
+        expect(list).to be_blank
       end
     end
   end

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -15,19 +15,21 @@ describe 'PostCreatedEdited' do
     it 'fires the trigger' do
       post = nil
 
-      output = JSON.parse(capture_stdout do
+      list = capture_contexts do
         post = PostCreator.create(user, basic_topic_params)
-      end)
+      end
 
-      expect(output['kind']).to eq('post_created_edited')
-      expect(output['action']).to eq('create')
+      expect(list.length).to eq(1)
+      expect(list[0]['kind']).to eq('post_created_edited')
+      expect(list[0]['action'].to_s).to eq('create')
 
-      output = JSON.parse(capture_stdout do
+      list = capture_contexts do
         post.revise(post.user, raw: 'this is another cool topic')
-      end)
+      end
 
-      expect(output['kind']).to eq('post_created_edited')
-      expect(output['action']).to eq('edit')
+      expect(list.length).to eq(1)
+      expect(list[0]['kind']).to eq('post_created_edited')
+      expect(list[0]['action'].to_s).to eq('edit')
     end
 
     context 'trust_levels are restricted' do
@@ -37,23 +39,24 @@ describe 'PostCreatedEdited' do
 
       context 'trust level is allowed' do
         it 'fires the trigger' do
-          output = JSON.parse(capture_stdout do
+          list = capture_contexts do
             user.trust_level = TrustLevel[0]
             PostCreator.create(user, basic_topic_params)
-          end)
+          end
 
-          expect(output['kind']).to eq('post_created_edited')
+          expect(list.length).to eq(1)
+          expect(list[0]['kind']).to eq('post_created_edited')
         end
       end
 
       context 'trust level is not allowed' do
         it 'doesn’t fire the trigger' do
-          output = capture_stdout do
+          list = capture_contexts do
             user.trust_level = TrustLevel[1]
             PostCreator.create(user, basic_topic_params)
           end
 
-          expect(output).to be_blank
+          expect(list).to be_blank
         end
       end
     end
@@ -65,11 +68,12 @@ describe 'PostCreatedEdited' do
 
       context 'category is allowed' do
         it 'fires the trigger' do
-          output = JSON.parse(capture_stdout do
+          list = capture_contexts do
             PostCreator.create(user, basic_topic_params.merge({ category: Category.first.id }))
-          end)
+          end
 
-          expect(output['kind']).to eq('post_created_edited')
+          expect(list.length).to eq(1)
+          expect(list[0]['kind']).to eq('post_created_edited')
         end
       end
 
@@ -77,11 +81,11 @@ describe 'PostCreatedEdited' do
         fab!(:category) { Fabricate(:category) }
 
         it 'doesn’t fire the trigger' do
-          output = capture_stdout do
+          list = capture_contexts do
             PostCreator.create(user, basic_topic_params.merge({ category: category.id }))
           end
 
-          expect(output).to be_blank
+          expect(list).to be_blank
         end
       end
     end

--- a/spec/triggers/user_added_to_group_spec.rb
+++ b/spec/triggers/user_added_to_group_spec.rb
@@ -19,11 +19,12 @@ describe 'UserAddedToGroup' do
 
   context 'group is tracked' do
     it 'fires the trigger' do
-      output = capture_stdout do
+      list = capture_contexts do
         tracked_group.add(user)
       end
 
-      expect(output).to include('"kind":"user_added_to_group"')
+      expect(list.length).to eq(1)
+      expect(list[0]["kind"]).to eq('user_added_to_group')
     end
   end
 
@@ -31,11 +32,11 @@ describe 'UserAddedToGroup' do
     let(:untracked_group) { Fabricate(:group) }
 
     it 'doesn’t fire the trigger' do
-      output = capture_stdout do
+      list = capture_contexts do
         untracked_group.add(user)
       end
 
-      expect(output).to_not include('"kind":"user_added_to_group"')
+      expect(list).to eq([])
     end
   end
 end

--- a/spec/triggers/user_badge_granted_spec.rb
+++ b/spec/triggers/user_badge_granted_spec.rb
@@ -19,11 +19,12 @@ describe 'UserBadgeGranted' do
 
   context 'a badge is granted' do
     it 'fires the trigger' do
-      output = JSON.parse(capture_stdout do
+      contexts = capture_contexts do
         BadgeGranter.grant(tracked_badge, user)
-      end)
+      end
 
-      expect(output['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
+      expect(contexts.length).to eq(1)
+      expect(contexts[0]['kind']).to eq(DiscourseAutomation::Triggerable::USER_BADGE_GRANTED)
     end
   end
 end


### PR DESCRIPTION
Previously we could only filter after post cooked triggers by category,
this enables tag filtering as well. (applicable to checked / edited by)

Also, contains a major refactor of testing which used to depend on stdout
capturing and json parsing which can be fragile if anything leaks onto stdout

New framework `capture_contexts` is more targetted and easier to consume
