### PR TITLE
DEV: Fix spec failure

### DIFF
--- a/spec/discourse_automation_helper.rb
+++ b/spec/discourse_automation_helper.rb
@@ -8,7 +8,7 @@ end
 
 module DiscourseAutomation::CapturedContext
   def self.add(context)
-    @contexts << context
+    @contexts << context if @capturing
   end
 
   def self.capture
@@ -21,7 +21,6 @@ module DiscourseAutomation::CapturedContext
   ensure
     @capturing = false
   end
-
 end
 
 DiscourseAutomation::Scriptable.add('something_about_us') do


### PR DESCRIPTION
It wasn't safe to emit events in specs outside `capture_contexts` blocks

```
  1) UserPromoted does not run if the user is being demoted
     Failure/Error: block.call(*args) if enabled?

     NoMethodError:
       undefined method `<<' for nil:NilClass
     # ./plugins/discourse-automation/spec/discourse_automation_helper.rb:11:in `add'
     # ./plugins/discourse-automation/spec/discourse_automation_helper.rb:28:in `block (2 levels) in <main>'
     # ./plugins/discourse-automation/app/models/discourse_automation/automation.rb:66:in `trigger!'
     # ./plugins/discourse-automation/plugin.rb:129:in `block in handle_user_promoted'
     # ./plugins/discourse-automation/plugin.rb:118:in `handle_user_promoted'
     # ./plugins/discourse-automation/plugin.rb:305:in `block (2 levels) in activate!'
     # ./lib/plugin/instance.rb:466:in `block in on'
     # ./lib/discourse_event.rb:14:in `block in trigger'
     # ./lib/discourse_event.rb:13:in `trigger'
     # ./spec/support/discourse_event_helper.rb:5:in `trigger'
     # ./lib/promotion.rb:83:in `block in change_trust_level!'
     # ./lib/promotion.rb:71:in `change_trust_level!'
     # ./app/models/user.rb:1193:in `change_trust_level!'
     # ./plugins/discourse-automation/spec/triggers/user_promoted_spec.rb:24:in `block (2 levels) in <main>'
     # ./spec/rails_helper.rb:278:in `block (2 levels) in <top (required)>'
```