### PR TITLE
DEV: Fix specs for personal_message_enabled_groups setting

### DIFF
--- a/spec/triggers/pm_created_spec.rb
+++ b/spec/triggers/pm_created_spec.rb
@@ -6,6 +6,7 @@ describe 'PMCreated' do
   before do
     SiteSetting.discourse_automation_enabled = true
     SiteSetting.personal_email_time_window_seconds = 0
+    Group.refresh_automatic_groups!
   end
 
   fab!(:user) { Fabricate(:user) }


### PR DESCRIPTION
See https://github.com/discourse/discourse/pull/18437, we are removing any references to enable_personal_messages in core and using only personal_message_enabled_groups, which requires auto groups to be assigned in certain specs for them to keep working.