### PR TITLE
FIX: prevents saving an enabled automation with no trigger

### DIFF
--- a/app/controllers/admin/discourse_automation/admin_discourse_automation_automations_controller.rb
+++ b/app/controllers/admin/discourse_automation/admin_discourse_automation_automations_controller.rb
@@ -42,14 +42,14 @@ module DiscourseAutomation
 
       if automation.trigger != params[:automation][:trigger]
         params[:automation][:fields] = []
-        automation.enabled = false
+        attributes[:enabled] = false
         automation.fields.destroy_all
       end
 
       if automation.script != params[:automation][:script]
-        params[:automation][:trigger] = nil
+        attributes[:trigger] = nil
         params[:automation][:fields] = []
-        automation.enabled = false
+        attributes[:enabled] = false
         automation.fields.destroy_all
         automation.tap { |r| r.assign_attributes(attributes) }.save!(validate: false)
       else

--- a/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
@@ -20,20 +20,6 @@
         </div>
       </div>
 
-      <div class="control-group automation-enabled">
-        <label class="control-label {{unless automationForm.enabled "disabled"}}">
-          {{i18n "discourse_automation.models.automation.enabled.label"}}
-        </label>
-
-        <div class="controls">
-          {{input
-            type="checkbox"
-            checked=automationForm.enabled
-            click=(action (mut automationForm.enabled) value="target.checked")
-          }}
-        </div>
-      </div>
-
       <div class="control-group">
         <label class="control-label">
           {{i18n "discourse_automation.models.script.name.label"}}
@@ -143,6 +129,17 @@
             {{/each}}
           </div>
         </section>
+      {{/if}}
+
+      {{#if automationForm.trigger}}
+        <div class="control-group automation-enabled alert alert-warning">
+          <span>{{i18n "discourse_automation.models.automation.enabled.label"}}</span>
+          {{input
+            type="checkbox"
+            checked=automationForm.enabled
+            click=(action (mut automationForm.enabled) value="target.checked")
+          }}
+        </div>
       {{/if}}
 
       <div class="control-group">

--- a/assets/stylesheets/common/discourse-automation.scss
+++ b/assets/stylesheets/common/discourse-automation.scss
@@ -53,7 +53,8 @@
     }
 
     &.alert-warning {
-      border-left-color: var(--highlight-low);
+      border-left-color: var(--highlight);
+      background: var(--highlight-low);
     }
 
     &.alert-error {
@@ -170,6 +171,16 @@
     }
 
     &.automation-enabled {
+      display: flex;
+      align-items: center;
+      justify-content: flex-start;
+      padding: 1em;
+
+      .ember-checkbox {
+        margin: 0 0 0 1em;
+        padding: 0;
+      }
+
       .control-label.disabled {
         color: var(--danger);
       }

--- a/spec/requests/admin_discourse_automation_automations_spec.rb
+++ b/spec/requests/admin_discourse_automation_automations_spec.rb
@@ -72,6 +72,54 @@ describe DiscourseAutomation::AdminDiscourseAutomationAutomationsController do
         end
       end
 
+      context 'when changing trigger and script of an enabled automation' do
+        it 'forces the automation to be disabled' do
+          expect(automation.enabled).to eq(true)
+
+          put "/admin/plugins/discourse-automation/automations/#{automation.id}.json", params: {
+            automation: {
+              script: "bar",
+              trigger: "foo",
+              enabled: true
+            }
+          }
+
+          expect(automation.reload.enabled).to eq(false)
+        end
+      end
+
+      context 'when changing trigger of an enabled automation' do
+        it 'forces the automation to be disabled' do
+          expect(automation.enabled).to eq(true)
+
+          put "/admin/plugins/discourse-automation/automations/#{automation.id}.json", params: {
+            automation: {
+              script: automation.script,
+              trigger: "foo",
+              enabled: true
+            }
+          }
+
+          expect(automation.reload.enabled).to eq(false)
+        end
+      end
+
+      context 'when changing script of an enabled automation' do
+        it 'disables the automation' do
+          expect(automation.enabled).to eq(true)
+
+          put "/admin/plugins/discourse-automation/automations/#{automation.id}.json", params: {
+            automation: {
+              trigger: automation.trigger,
+              script: "foo",
+              enabled: true
+            }
+          }
+
+          expect(automation.reload.enabled).to eq(false)
+        end
+      end
+
       context 'with invalid field’s metadata' do
         it 'errors' do
           put "/admin/plugins/discourse-automation/automations/#{automation.id}.json", params: {


### PR DESCRIPTION
Under specific circumstances, automation could be saved as enabled without a trigger, leading to the automation staying enabled after adding an uncompleted trigger.

This could eventually be moved into some automation validation, but that can be pretty tricky to do given the chicken-egg situation of script needing trigger, trigger requiring automation, ... and other added complexity like the validity of relationships (fields of the scripts/triggers, enabled or not...).

The enabled checkbox has been moved to the bottom and, more importantly, is only showing if a trigger is set. We could need a different pattern for this as in the past, having this field at the bottom led to people not seeing it, but this is too much complexity for now.