### PR TITLE
DEV: re-order trigger date code to match recurrence choices

### DIFF
--- a/app/lib/discourse_automation/triggers/recurring.rb
+++ b/app/lib/discourse_automation/triggers/recurring.rb
@@ -15,64 +15,54 @@ RECURRENCE_CHOICES = [
 def setup_pending_automation(automation, fields)
   automation.pending_automations.destroy_all
 
-  start_date = fields.dig("start_date", "value")
-  return if !start_date
+  return unless start_date = fields.dig("start_date", "value")
+  return unless interval = fields.dig("recurrence", "value", "interval")
+  return unless frequency = fields.dig("recurrence", "value", "frequency")
+
   start_date = Time.parse(start_date)
-
-  interval = fields.dig("recurrence", "value", "interval")
-  return if !interval
-
-  frequency = fields.dig("recurrence", "value", "frequency")
-  return if !frequency
-
   byday = start_date.strftime("%A").upcase[0, 2]
   interval = interval.to_i
   interval_end = interval + 1
 
-  case frequency
-  when "day"
-    next_trigger_date =
+  next_trigger_date =
+    case frequency
+    when "minute"
+      (Time.zone.now + interval.minute).beginning_of_minute
+    when "hour"
+      (Time.zone.now + interval.hour).beginning_of_hour
+    when "day"
       RRule::Rule
         .new("FREQ=DAILY;INTERVAL=#{interval}", dtstart: start_date)
         .between(Time.now.end_of_day, interval_end.days.from_now)
         .first
-  when "month"
-    count = 0
-    (start_date.beginning_of_month.to_date..start_date.end_of_month.to_date).each do |date|
-      count += 1 if date.strftime("%A") == start_date.strftime("%A")
-      break if date.day == start_date.day
-    end
-
-    next_trigger_date =
-      RRule::Rule
-        .new("FREQ=MONTHLY;INTERVAL=#{interval};BYDAY=#{count}#{byday}", dtstart: start_date)
-        .between(Time.now, interval_end.months.from_now)
-        .first
-  when "weekday"
-    max_weekends = (interval_end.to_f / 5).ceil
-    next_trigger_date =
+    when "weekday"
+      max_weekends = (interval_end.to_f / 5).ceil
       RRule::Rule
         .new("FREQ=DAILY;BYDAY=MO,TU,WE,TH,FR", dtstart: start_date)
         .between(Time.now.end_of_day, max_weekends.weeks.from_now)
         .drop(interval - 1)
         .first
-  when "week"
-    next_trigger_date =
+    when "week"
       RRule::Rule
         .new("FREQ=WEEKLY;INTERVAL=#{interval};BYDAY=#{byday}", dtstart: start_date)
         .between(Time.now.end_of_week, interval_end.weeks.from_now)
         .first
-  when "hour"
-    next_trigger_date = (Time.zone.now + interval.hour).beginning_of_hour
-  when "minute"
-    next_trigger_date = (Time.zone.now + interval.minute).beginning_of_minute
-  when "year"
-    next_trigger_date =
+    when "month"
+      count = 0
+      (start_date.beginning_of_month.to_date..start_date.end_of_month.to_date).each do |date|
+        count += 1 if date.strftime("%A") == start_date.strftime("%A")
+        break if date.day == start_date.day
+      end
+      RRule::Rule
+        .new("FREQ=MONTHLY;INTERVAL=#{interval};BYDAY=#{count}#{byday}", dtstart: start_date)
+        .between(Time.now, interval_end.months.from_now)
+        .first
+    when "year"
       RRule::Rule
         .new("FREQ=YEARLY;INTERVAL=#{interval}", dtstart: start_date)
         .between(Time.now, interval_end.years.from_now)
         .first
-  end
+    end
 
   if next_trigger_date && next_trigger_date > Time.zone.now
     automation.pending_automations.create!(execute_at: next_trigger_date)

--- a/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
+++ b/assets/javascripts/discourse/templates/admin-plugins-discourse-automation-edit.hbs
@@ -31,9 +31,7 @@
             value=automationForm.script
             content=model.scriptables
             onChange=(action "onChangeScript")
-            options=(hash
-              filterable=true
-            )
+            options=(hash filterable=true)
           }}
         </div>
       </div>
@@ -45,10 +43,11 @@
       </h2>
 
       <div class="control-group">
-
         {{#if model.automation.script.forced_triggerable}}
           <div class="alert alert-warning">
-            {{i18n "discourse_automation.edit_automation.trigger_section.forced"}}
+            {{i18n
+              "discourse_automation.edit_automation.trigger_section.forced"
+            }}
           </div>
         {{/if}}
 
@@ -78,11 +77,19 @@
           </div>
         {{/if}}
 
-        {{#if (and model.automation.enabled  model.automation.trigger.settings.manual_trigger)}}
+        {{#if
+          (and
+            model.automation.enabled
+            model.automation.trigger.settings.manual_trigger
+          )
+        }}
           <div class="alert alert-info next-trigger">
 
             {{#if nextPendingAutomationAtFormatted}}
-              <p>{{i18n "discourse_automation.edit_automation.trigger_section.next_pending_automation" date=nextPendingAutomationAtFormatted}}</p>
+              <p>{{i18n
+                  "discourse_automation.edit_automation.trigger_section.next_pending_automation"
+                  date=nextPendingAutomationAtFormatted
+                }}</p>
             {{/if}}
 
             {{d-button
@@ -133,7 +140,9 @@
 
       {{#if automationForm.trigger}}
         <div class="control-group automation-enabled alert alert-warning">
-          <span>{{i18n "discourse_automation.models.automation.enabled.label"}}</span>
+          <span>{{i18n
+              "discourse_automation.models.automation.enabled.label"
+            }}</span>
           {{input
             type="checkbox"
             checked=automationForm.enabled


### PR DESCRIPTION
No logic changed, just re-ordering the `next_trigger_date` switch to go from the smallest frequency to the highest (and match the order of the `RECURRENCE_CHOICES` array.

The `admin-plugins-discourse-automation-edit.hbs` was also linted.