### PR TITLE
Add email group user field

### DIFF
--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -153,6 +153,12 @@ module DiscourseAutomation
           "type" => "integer",
         },
       },
+      "email_group_user" => {
+        "value" => {
+          "type" => "array",
+          "items" => [{ type: "string" }],
+        },
+      },
       "pms" => {
         type: "array",
         items: [

--- a/assets/javascripts/discourse/components/fields/da-email-group-user-field.js
+++ b/assets/javascripts/discourse/components/fields/da-email-group-user-field.js
@@ -1,0 +1,61 @@
+import BaseField from "./da-base-field";
+import { action, computed } from "@ember/object";
+import discourseComputed from "discourse-common/utils/decorators";
+
+export default class EmailGroupUserField extends BaseField {
+  init() {
+    super.init(...arguments);
+    this.set("_groups", []);
+  }
+
+  didInsertElement() {
+    this._super(...arguments);
+
+    if (this.focusTarget === "usernames") {
+      this.element.querySelector(".select-kit .select-kit-header").focus();
+    }
+  }
+
+  @discourseComputed("recipients")
+  splitRecipients(recipients) {
+    if (Array.isArray(recipients)) {
+      return recipients;
+    }
+    return recipients ? recipients.split(",").filter(Boolean) : [];
+  }
+
+  _updateGroups(selected, newGroups) {
+    const groups = [];
+    this._groups.forEach((existing) => {
+      if (selected.includes(existing)) {
+        groups.addObject(existing);
+      }
+    });
+    newGroups.forEach((newGroup) => {
+      if (!groups.includes(newGroup)) {
+        groups.addObject(newGroup);
+      }
+    });
+    this.setProperties({
+      _groups: groups,
+      hasGroups: groups.length > 0,
+    });
+  }
+
+  @action
+  updateRecipients(selected, content) {
+    const newGroups = content.filterBy("isGroup").mapBy("id");
+    this._updateGroups(selected, newGroups);
+    this.set("recipients", selected.join(","));
+  }
+
+  @computed("field.extra.content.[]")
+  get replacedContent() {
+    return (this.field.extra.content || []).map((r) => {
+      return {
+        id: r.id,
+        name: r.name,
+      };
+    });
+  }
+}

--- a/assets/javascripts/discourse/templates/components/fields/da-email-group-user-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-email-group-user-field.hbs
@@ -1,0 +1,21 @@
+<section class="field email-group-user-field">
+  <div class="control-group">
+    {{fields/da-field-label label=label field=field}}
+
+    <div class="controls">
+      {{email-group-user-chooser
+        value=field.metadata.value
+        onChange=(action (mut field.metadata.value))
+        options=(hash
+          includeGroups=true
+          includeMessageableGroups=true
+          allowEmails=true
+          autoWrap=true
+          disabled=field.isDisabled
+        )
+      }}
+
+      {{fields/da-field-description description=description}}
+    </div>
+  </div>
+</section>

--- a/test/javascripts/integration/components/email-group-user-field-test.js
+++ b/test/javascripts/integration/components/email-group-user-field-test.js
@@ -1,0 +1,23 @@
+import { module, test } from "qunit";
+import { hbs } from "ember-cli-htmlbars";
+import { render } from "@ember/test-helpers";
+import { setupRenderingTest } from "discourse/tests/helpers/component-test";
+import { exists, query } from "discourse/tests/helpers/qunit-helpers";
+
+module("Integration | Component | email-group-user-field", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("Email group user field uses email-group-user-chooser component", async function (assert) {
+    const template = hbs` <Fields::DaEmailGroupUserField @label="a label" />`;
+
+    await render(template);
+
+    assert.equal(query(".control-label").innerText, "a label");
+    assert.ok(
+      exists(
+        ".controls details.select-kit.multi-select.user-chooser.email-group-user-chooser"
+      ),
+      "has email-group-user-chooser"
+    );
+  });
+});


### PR DESCRIPTION
Add new field for email-group-user, which allows adding 3 different user types in a multi select field.