### PR TITLE
FIX: Do not error on deleted topic in post script

### DIFF
--- a/app/lib/discourse_automation/scripts/post.rb
+++ b/app/lib/discourse_automation/scripts/post.rb
@@ -15,15 +15,14 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
 
   script do |context, fields, automation|
     creator_username = fields.dig("creator", "value") || Discourse.system_user.username
+    topic_id = fields.dig("topic", "value")
+    post_raw = fields.dig("post", "value")
 
     placeholders = { creator_username: creator_username }.merge(context["placeholders"] || {})
 
-    creator = User.find_by!(username: creator_username)
+    creator = User.find_by(username: creator_username)
+    topic = Topic.find_by(id: topic_id)
 
-    PostCreator.new(
-      creator,
-      topic_id: fields.dig("topic", "value"),
-      raw: fields.dig("post", "value"),
-    ).create!
+    PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator && topic
   end
 end

--- a/spec/scripts/post_spec.rb
+++ b/spec/scripts/post_spec.rb
@@ -37,6 +37,16 @@ describe "Post" do
         }.to change { topic_1.posts.count }.by(1)
       end
     end
+
+    context "when topic is deleted" do
+      before { topic_1.trash! }
+
+      it "does nothing and does not error" do
+        freeze_time 6.hours.from_now do
+          expect { Jobs::DiscourseAutomationTracker.new.execute }.not_to change { Post.count }
+        end
+      end
+    end
   end
 
   context "when using recurring trigger" do


### PR DESCRIPTION
If the topic was deleted and a post script ran, we would
get this error:

> Job exception: Something has gone wrong. Perhaps this topic was closed or deleted while you were looking at it?

We can't create a post on a deleted topic, so just do nothing
if that happens.
