### PR TITLE
FIC: stores encrypt preference in pending PMs

### DIFF
--- a/app/jobs/scheduled/discourse_automation_tracker.rb
+++ b/app/jobs/scheduled/discourse_automation_tracker.rb
@@ -24,8 +24,9 @@ module Jobs
 
     def send_pending_pm(pending_pm)
       DiscourseAutomation::Scriptable::Utils.send_pm(
-        pending_pm.attributes.slice("target_usernames", "title", "raw"),
+        pending_pm.attributes.slice("target_usernames", "title", "raw",),
         sender: pending_pm.sender,
+        prefers_encrypt: pending_pm.prefers_encrypt,
       )
 
       pending_pm.destroy!

--- a/app/lib/discourse_automation/scriptable.rb
+++ b/app/lib/discourse_automation/scriptable.rb
@@ -194,21 +194,23 @@ module DiscourseAutomation
         sender: Discourse.system_user.username,
         delay: nil,
         automation_id: nil,
-        encrypt: true
+        prefers_encrypt: true
       )
         pm = pm.symbolize_keys
+        prefers_encrypt = prefers_encrypt && defined?(EncryptedPostCreator)
 
-        if delay && automation_id
+        if delay && delay.to_i > 0 && automation_id
           pm[:execute_at] = delay.to_i.minutes.from_now
           pm[:sender] = sender
           pm[:automation_id] = automation_id
+          pm[:prefers_encrypt] = prefers_encrypt
           DiscourseAutomation::PendingPm.create!(pm)
         else
           if sender = User.find_by(username: sender)
             post_created = false
             pm = pm.merge(archetype: Archetype.private_message)
 
-            if encrypt && defined?(EncryptedPostCreator)
+            if prefers_encrypt
               pm[:target_usernames] = (pm[:target_usernames] || []).join(",")
               post_created = EncryptedPostCreator.new(sender, pm).create
             end

--- a/app/lib/discourse_automation/scripts/gift_exchange.rb
+++ b/app/lib/discourse_automation/scripts/gift_exchange.rb
@@ -62,7 +62,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::GIFT_EXCHAN
         utils.send_pm(
           { target_usernames: Array(gifter), title: title, raw: raw },
           delay: giftee_assignment_message["delay"],
-          encrypt: giftee_assignment_message["encrypt"],
+          prefers_encrypt: giftee_assignment_message["prefers_encrypt"],
           automation_id: automation.id,
         )
       end

--- a/app/lib/discourse_automation/scripts/send_pms.rb
+++ b/app/lib/discourse_automation/scripts/send_pms.rb
@@ -49,7 +49,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::SEND_PMS) d
           sender: sender_username,
           automation_id: automation.id,
           delay: sendable["delay"],
-          encrypt: sendable["encrypt"],
+          prefers_encrypt: sendable["prefers_encrypt"],
         )
       end
     end

--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -174,7 +174,7 @@ module DiscourseAutomation
               "delay" => {
                 "type" => "integer",
               },
-              "encrypt" => {
+              "prefers_encrypt" => {
                 "type" => "boolean",
               },
             },

--- a/assets/javascripts/discourse/components/fields/da-pms-field.js
+++ b/assets/javascripts/discourse/components/fields/da-pms-field.js
@@ -30,7 +30,7 @@ export default class PmsField extends BaseField {
       title: "",
       raw: "",
       delay: 0,
-      encrypt: true,
+      prefers_encrypt: true,
     });
   }
 }

--- a/assets/javascripts/discourse/templates/components/fields/da-pms-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-pms-field.hbs
@@ -73,14 +73,14 @@
 
       <div class="control-group">
         <label class="control-label">
-          {{i18n "discourse_automation.fields.pms.encrypt.label"}}
+          {{i18n "discourse_automation.fields.pms.prefers_encrypt.label"}}
         </label>
 
         <div class="controls">
           {{input
             type="checkbox"
-            checked=pm.encrypt
-            click=(action (mut pm.encrypt) value="target.checked")
+            checked=pm.prefers_encrypt
+            click=(action (mut pm.prefers_encrypt) value="target.checked")
             disabled=field.isDisabled
           }}
         </div>

--- a/config/locales/client.ar.yml
+++ b/config/locales/client.ar.yml
@@ -46,7 +46,7 @@ ar:
             label: النص
           delay:
             label: التأخير (بالدقائق)
-          encrypt:
+          prefers_encrypt:
             label: يشفِّر الرسائل الشخصية إذا كانت متاحة
         group:
           label: المجموعة

--- a/config/locales/client.de.yml
+++ b/config/locales/client.de.yml
@@ -46,7 +46,7 @@ de:
             label: Body
           delay:
             label: Verzögerung (Minuten)
-          encrypt:
+          prefers_encrypt:
             label: Verschlüsselt PN, falls verfügbar
         group:
           label: Gruppe

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -40,7 +40,7 @@ en:
             label: Body
           delay:
             label: Delay (minutes)
-          encrypt:
+          prefers_encrypt:
             label: Encrypts PM if available
         group:
           label: Group

--- a/config/locales/client.es.yml
+++ b/config/locales/client.es.yml
@@ -46,7 +46,7 @@ es:
             label: Cuerpo
           delay:
             label: Retardo (en minutos)
-          encrypt:
+          prefers_encrypt:
             label: Cifrar el mensaje cuando sea posible
         group:
           label: Grupo

--- a/config/locales/client.fi.yml
+++ b/config/locales/client.fi.yml
@@ -46,7 +46,7 @@ fi:
             label: Teksti
           delay:
             label: Viive (minuutteina)
-          encrypt:
+          prefers_encrypt:
             label: Salaa yksityisviestin, jos käytettävissä
         group:
           label: Ryhmä

--- a/config/locales/client.fr.yml
+++ b/config/locales/client.fr.yml
@@ -46,7 +46,7 @@ fr:
             label: Corps
           delay:
             label: Délai (minutes)
-          encrypt:
+          prefers_encrypt:
             label: Chiffrer le MP si disponible
         group:
           label: Groupe

--- a/config/locales/client.hu.yml
+++ b/config/locales/client.hu.yml
@@ -46,7 +46,7 @@ hu:
             label: Törzs
           delay:
             label: Késleltetés (perc)
-          encrypt:
+          prefers_encrypt:
             label: PÜ titkosítása, ha elérhető
         group:
           label: Csoport

--- a/config/locales/client.it.yml
+++ b/config/locales/client.it.yml
@@ -46,7 +46,7 @@ it:
             label: Corpo
           delay:
             label: Ritardo (minuti)
-          encrypt:
+          prefers_encrypt:
             label: Applica crittografia ai MP se disponibile
         group:
           label: Gruppo

--- a/config/locales/client.ja.yml
+++ b/config/locales/client.ja.yml
@@ -46,7 +46,7 @@ ja:
             label: 本文
           delay:
             label: 遅延（分）
-          encrypt:
+          prefers_encrypt:
             label: 可能な場合は PM を暗号化する
         group:
           label: グループ

--- a/config/locales/client.nl.yml
+++ b/config/locales/client.nl.yml
@@ -46,7 +46,7 @@ nl:
             label: Tekst
           delay:
             label: Vertraging (minuten)
-          encrypt:
+          prefers_encrypt:
             label: Versleutelt PB indien beschikbaar
         group:
           label: Groep

--- a/config/locales/client.pt_BR.yml
+++ b/config/locales/client.pt_BR.yml
@@ -46,7 +46,7 @@ pt_BR:
             label: Corpo
           delay:
             label: Atraso (minutos)
-          encrypt:
+          prefers_encrypt:
             label: Criptografa PM, se disponível
         group:
           label: Grupo

--- a/config/locales/client.ru.yml
+++ b/config/locales/client.ru.yml
@@ -46,7 +46,7 @@ ru:
             label: Тело сообщения
           delay:
             label: Задержка (в минутах)
-          encrypt:
+          prefers_encrypt:
             label: Шифрует ЛС, если это возможно
         group:
           label: Группа

--- a/config/locales/client.sv.yml
+++ b/config/locales/client.sv.yml
@@ -46,7 +46,7 @@ sv:
             label: Kropp
           delay:
             label: Fördröjning (minuter)
-          encrypt:
+          prefers_encrypt:
             label: Krypterar PM om tillgängligt
         group:
           label: Grupp

--- a/config/locales/client.tr_TR.yml
+++ b/config/locales/client.tr_TR.yml
@@ -46,7 +46,7 @@ tr_TR:
             label: Gövde
           delay:
             label: Gecikme (dakika)
-          encrypt:
+          prefers_encrypt:
             label: Mümkünse özel mesajı şifreler
         group:
           label: Grup

--- a/config/locales/client.zh_CN.yml
+++ b/config/locales/client.zh_CN.yml
@@ -46,7 +46,7 @@ zh_CN:
             label: 正文
           delay:
             label: 延迟（分钟）
-          encrypt:
+          prefers_encrypt:
             label: 加密 PM（如果可用）
         group:
           label: 群组

--- a/db/migrate/20210528203310_post_migrate_gift_from_pm_to_pms.rb
+++ b/db/migrate/20210528203310_post_migrate_gift_from_pm_to_pms.rb
@@ -20,7 +20,7 @@ class PostMigrateGiftFromPmToPms < ActiveRecord::Migration[6.1]
             title: pm["title"],
             raw: pm["body"],
             delay: pm["delay"] || 0,
-            encrypt: pm["encrypt"] || true,
+            prefers_encrypt: pm["encrypt"] || true,
           },
         ],
       }

--- a/db/migrate/20230412120414_add_prefers_encrypt_field_to_pending_pms.rb
+++ b/db/migrate/20230412120414_add_prefers_encrypt_field_to_pending_pms.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddPrefersEncryptFieldToPendingPms < ActiveRecord::Migration[7.0]
+  def change
+    add_column :discourse_automation_pending_pms, :prefers_encrypt, :boolean, null: false, default: false
+  end
+end


### PR DESCRIPTION
When a PM was delayed the encrypt preference was not stored, as the default was true, it would always get encrypted.