### PR TITLE
FIX: Update migration to prevent `PG::NotNullViolation` error

### DIFF
--- a/db/migrate/20230412120414_add_prefers_encrypt_field_to_pending_pms.rb
+++ b/db/migrate/20230412120414_add_prefers_encrypt_field_to_pending_pms.rb
@@ -2,10 +2,13 @@
 
 class AddPrefersEncryptFieldToPendingPms < ActiveRecord::Migration[7.0]
   def change
-    add_column :discourse_automation_pending_pms,
-               :prefers_encrypt,
-               :boolean,
-               null: false,
-               default: false
+    add_column :discourse_automation_pending_pms, :prefers_encrypt, :boolean, default: false
+
+    execute <<~SQL
+      UPDATE discourse_automation_pending_pms
+      SET prefers_encrypt = false
+    SQL
+
+    change_column_null :discourse_automation_pending_pms, :prefers_encrypt, false
   end
 end


### PR DESCRIPTION
Since there are already rows in `discourse_automation_pending_pms`, we
cannot add a column with `null: false`. Instead we need to first add the
column, fill it up with values and then change the column default.