### PR TITLE
FIX: PG::NotNullViolation when prefers_encrypt is not set

### DIFF
--- a/app/lib/discourse_automation/scripts/send_pms.rb
+++ b/app/lib/discourse_automation/scripts/send_pms.rb
@@ -49,7 +49,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::SEND_PMS) d
           sender: sender_username,
           automation_id: automation.id,
           delay: sendable["delay"],
-          prefers_encrypt: sendable["prefers_encrypt"],
+          prefers_encrypt: !!sendable["prefers_encrypt"],
         )
       end
     end

--- a/spec/scripts/send_pms_spec.rb
+++ b/spec/scripts/send_pms_spec.rb
@@ -93,7 +93,29 @@ describe "SendPms" do
 
     before { automation.update!(trigger: DiscourseAutomation::Triggerable::RECURRING) }
 
-    it "correctly stores encrypt preference" do
+    it "correctly sets encrypt preference to false even when option is not specified" do
+      automation.upsert_field!(
+        "sendable_pms",
+        "pms",
+        {
+          value: [
+            {
+              title: "A message from %%SENDER_USERNAME%%",
+              raw: "This is a message sent to @%%RECEIVER_USERNAME%%",
+              delay: 1,
+            },
+          ],
+        },
+        target: "script",
+      )
+      automation.upsert_field!("receiver", "user", { value: Discourse.system_user.username })
+
+      automation.trigger!
+
+      expect(DiscourseAutomation::PendingPm.last.prefers_encrypt).to eq(false)
+    end
+
+    it "correctly stores encrypt preference to false" do
       automation.upsert_field!(
         "sendable_pms",
         "pms",


### PR DESCRIPTION
This reverts commit bcd604a25bd2a99e4babe77e6c712b59fd49550b.