### PR TITLE
DEV: Allow clearing choices dropdowns, cleanup

### DIFF
--- a/assets/javascripts/discourse/templates/components/fields/da-choices-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-choices-field.hbs
@@ -6,7 +6,7 @@
       value=field.metadata.value
       content=replacedContent
       onChange=(action (mut field.metadata.value))
-      options=(hash allowAny=false disabled=field.isDisabled)
+      options=(hash allowAny=false clearable=true disabled=field.isDisabled)
     }}
 
     {{fields/da-field-description description=description}}

--- a/lib/discourse_automation/triggers/topic_created.rb
+++ b/lib/discourse_automation/triggers/topic_created.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-DiscourseAutomation::Triggerable::TOPIC_CREATED = "topic_created"
-
-DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::TOPIC_CREATED) do
-  field :valid_trust_levels, component: :"trust-levels"
-end


### PR DESCRIPTION
Unused `topic_created.rb` trigger was added in [ab0e934](https://github.com/discourse/discourse-automation/commit/ab0e9349631172727f38c31d1cc5ad3eaef55906). 