### PR TITLE
FEATURE: adds user_first_logged_in trigger

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -11,6 +11,9 @@ en:
       user_badge_granted:
         title: User badge granted
         doc: Triggers an automation when a user is granted a badge.
+      user_first_logged_in:
+        title: User first logged in
+        doc: Triggers an automation when a user logs in for the first time.
       stalled_topic:
         title: Stalled topic
         doc: Triggers an automation when the topic has not received a new reply from topic owner for a specified period of time. It is recommended to scope this trigger to a tag/category as the number of topics impacted can be very high. As a safety measure, the number of impacted topics is capped at 250.

--- a/lib/discourse_automation/triggers/user_first_logged_in.rb
+++ b/lib/discourse_automation/triggers/user_first_logged_in.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN = "user_first_logged_in"
+
+DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN) {}

--- a/spec/scripts/add_user_to_group_through_custom_field_spec.rb
+++ b/spec/scripts/add_user_to_group_through_custom_field_spec.rb
@@ -69,7 +69,7 @@ describe "AddUserTogroupThroughCustomField" do
     end
   end
 
-  context "with user_added_to_group trigger" do
+  context "with user_first_logged_in trigger" do
     fab!(:automation) do
       Fabricate(
         :automation,
@@ -79,16 +79,18 @@ describe "AddUserTogroupThroughCustomField" do
 
     context "with existing custom fields" do
       before do
+        user_field =
+          UserField.create!(name: "groupity_group", field_type: "text", description: "a nice field")
         UserCustomField.create!(
           user_id: user_1.id,
-          name: "groupity_group",
+          name: "user_field_#{user_field.id}",
           value: target_group.full_name,
         )
       end
 
       it "adds the user to the group" do
         automation.trigger!(
-          "kind" => DiscourseAutomation::Triggerable::USER_ADDED_TO_GROUP,
+          "kind" => DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN,
           "user" => user_1,
         )
 
@@ -100,7 +102,7 @@ describe "AddUserTogroupThroughCustomField" do
       it "does nothing" do
         expect {
           automation.trigger!(
-            "kind" => DiscourseAutomation::Triggerable::USER_ADDED_TO_GROUP,
+            "kind" => DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN,
             "user" => user_1,
           )
         }.not_to change { user_1.reload.belonging_to_group_ids.length }
@@ -108,12 +110,20 @@ describe "AddUserTogroupThroughCustomField" do
     end
 
     context "with non existing target group" do
-      before { UserCustomField.create!(user_id: user_1.id, name: "groupity_group", value: "xx") }
+      before do
+        user_field =
+          UserField.create!(name: "groupity_group", field_type: "text", description: "a nice field")
+        UserCustomField.create!(
+          user_id: user_1.id,
+          name: "user_field_#{user_field.id}",
+          value: "xx",
+        )
+      end
 
       it "does nothing" do
         expect {
           automation.trigger!(
-            "kind" => DiscourseAutomation::Triggerable::USER_ADDED_TO_GROUP,
+            "kind" => DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN,
             "user" => user_1,
           )
         }.not_to change { user_1.reload.belonging_to_group_ids.length }

--- a/spec/triggers/user_first_logged_in_spec.rb
+++ b/spec/triggers/user_first_logged_in_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require_relative "../discourse_automation_helper"
+
+describe DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN do
+  before { SiteSetting.discourse_automation_enabled = true }
+
+  fab!(:user) { Fabricate(:user) }
+  let(:topic) { post.topic }
+
+  fab!(:automation) do
+    Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN)
+  end
+
+  context "when user logs in for first time" do
+    it "triggers the automation" do
+      contexts = capture_contexts { user.logged_in }
+
+      expect(contexts[0]["kind"]).to eq(DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN)
+      expect(contexts[0]["user"]).to eq(user)
+    end
+  end
+
+  context "when user logs in multiple times" do
+    it "doesn’t trigger the automation" do
+      user.update_last_seen!(2.days.ago)
+      contexts = capture_contexts { user.logged_in }
+
+      expect(contexts).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Adds a new `user_first_logged_in` trigger and makes it available to `add_user_to_group_through_custom_field` script.

It replaces using `user_added_to_group` which was happening too late for this use case.

Example UI of an automation using it:

<img width="599" alt="Screenshot 2023-05-18 at 11 03 46" src="https://github.com/discourse/discourse-automation/assets/339945/ed596982-675d-45ba-9675-37b739c99789">
