### PR TITLE
FIX: Allow choices components to be reset

### DIFF
--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -86,7 +86,7 @@ module DiscourseAutomation
       },
       "choices" => {
         "value" => {
-          "type" => %w[string integer],
+          "type" => %w[string integer null],
         },
       },
       "tags" => {

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -81,6 +81,32 @@ describe DiscourseAutomation::Field do
       expect(field).to be_valid
     end
 
+    it "works with an integer value" do
+      field =
+        DiscourseAutomation::Field.create(
+          automation: automation,
+          component: "choices",
+          name: "foo",
+          metadata: {
+            value: 21,
+          },
+        )
+      expect(field).to be_valid
+    end
+
+    it "does not work with an array value" do
+      field =
+        DiscourseAutomation::Field.create(
+          automation: automation,
+          component: "choices",
+          name: "foo",
+          metadata: {
+            value: [1, 2, 3],
+          },
+        )
+      expect(field).to_not be_valid
+    end
+
     it "works with a nil value" do
       field =
         DiscourseAutomation::Field.create(

--- a/spec/models/field_spec.rb
+++ b/spec/models/field_spec.rb
@@ -62,4 +62,36 @@ describe DiscourseAutomation::Field do
       expect(field).to be_valid
     end
   end
+
+  describe "choices field" do
+    DiscourseAutomation::Scriptable.add("test_choices_field") { field :foo, component: :choices }
+
+    fab!(:automation) { Fabricate(:automation, script: "test_choices_field") }
+
+    it "works with a string value" do
+      field =
+        DiscourseAutomation::Field.create(
+          automation: automation,
+          component: "choices",
+          name: "foo",
+          metadata: {
+            value: "some text",
+          },
+        )
+      expect(field).to be_valid
+    end
+
+    it "works with a nil value" do
+      field =
+        DiscourseAutomation::Field.create(
+          automation: automation,
+          component: "choices",
+          name: "foo",
+          metadata: {
+            value: nil,
+          },
+        )
+      expect(field).to be_valid
+    end
+  end
 end


### PR DESCRIPTION
Fixes an issue where emptying a choices component would fail validation (and skip saving the edit): 

<img width="1093" alt="image" src="https://github.com/discourse/discourse-automation/assets/368961/a39fd1cc-f3e1-499a-917c-f6fbb0421b12">
