### PR TITLE
FEATURE: Support subcategories in `post_created_edited` and `after_post_cook`

### DIFF
--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -17,8 +17,8 @@ module DiscourseAutomation
 
           restricted_category = automation.trigger_field("restricted_category")
           if restricted_category["value"]
-            category_id = post.topic&.category&.id
-            next if restricted_category["value"] != category_id
+            category_ids = [post.topic&.category&.parent_category&.id, post.topic&.category&.id]
+            next if !category_ids.compact.include?(restricted_category["value"])
           end
 
           action_type = automation.trigger_field("action_type")
@@ -89,8 +89,8 @@ module DiscourseAutomation
 
           restricted_category = automation.trigger_field("restricted_category")
           if restricted_category["value"]
-            category_id = post.topic&.category&.id
-            next if restricted_category["value"] != category_id
+            category_ids = [post.topic&.category&.parent_category&.id, post.topic&.category&.id]
+            next if !category_ids.compact.include?(restricted_category["value"])
           end
 
           restricted_tags = automation.trigger_field("restricted_tags")

--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -17,7 +17,7 @@ module DiscourseAutomation
 
           restricted_category = automation.trigger_field("restricted_category")
           if restricted_category["value"]
-            category_id = post.topic&.category&.parent_category&.id || post.topic&.category&.id
+            category_id = post.topic&.category&.id
             next if restricted_category["value"] != category_id
           end
 
@@ -89,7 +89,7 @@ module DiscourseAutomation
 
           restricted_category = automation.trigger_field("restricted_category")
           if restricted_category["value"]
-            category_id = post.topic&.category&.parent_category&.id || post.topic&.category&.id
+            category_id = post.topic&.category&.id
             next if restricted_category["value"] != category_id
           end
 

--- a/spec/triggers/after_post_cook_spec.rb
+++ b/spec/triggers/after_post_cook_spec.rb
@@ -7,6 +7,8 @@ describe DiscourseAutomation::Triggerable::AFTER_POST_COOK do
 
   fab!(:post) { Fabricate(:post) }
   let(:topic) { post.topic }
+  let(:parent_category) { Fabricate(:category_with_definition) }
+  let(:subcategory) { Fabricate(:category_with_definition, parent_category_id: parent_category.id) }
 
   fab!(:automation) do
     Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::AFTER_POST_COOK)
@@ -39,6 +41,47 @@ describe DiscourseAutomation::Triggerable::AFTER_POST_COOK do
 
       expect(list.length).to eq(1)
       expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggerable::AFTER_POST_COOK)
+    end
+  end
+
+  context "when filtered to a category" do
+    context "when restricted to a subcategory" do
+      before do
+        automation.upsert_field!(
+          "restricted_category",
+          "category",
+          { value: subcategory.id },
+          target: "trigger",
+        )
+        topic.category = subcategory
+        topic.save!
+      end
+
+      it "fires the trigger" do
+        list = capture_contexts { post.rebake! }
+
+        expect(list.length).to eq(1)
+        expect(list[0]["kind"]).to eq(DiscourseAutomation::Triggerable::AFTER_POST_COOK)
+      end
+    end
+
+    context "when restricted to a different category" do
+      before do
+        automation.upsert_field!(
+          "restricted_category",
+          "category",
+          { value: parent_category.id },
+          target: "trigger",
+        )
+        topic.category = subcategory
+        topic.save!
+      end
+
+      it "does not fire the trigger" do
+        list = capture_contexts { post.rebake! }
+
+        expect(list.length).to eq(0)
+      end
     end
   end
 end

--- a/spec/triggers/after_post_cook_spec.rb
+++ b/spec/triggers/after_post_cook_spec.rb
@@ -65,7 +65,7 @@ describe DiscourseAutomation::Triggerable::AFTER_POST_COOK do
       end
     end
 
-    context "when restricted to a different category" do
+    context "when restricted to a parent category" do
       before do
         automation.upsert_field!(
           "restricted_category",
@@ -77,10 +77,10 @@ describe DiscourseAutomation::Triggerable::AFTER_POST_COOK do
         topic.save!
       end
 
-      it "does not fire the trigger" do
+      it "fires the trigger for a subcategory" do
         list = capture_contexts { post.rebake! }
 
-        expect(list.length).to eq(0)
+        expect(list.length).to eq(1)
       end
     end
   end

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -8,6 +8,9 @@ describe "PostCreatedEdited" do
   let(:basic_topic_params) do
     { title: "hello world topic", raw: "my name is fred", archetype_id: 1 }
   end
+  let(:parent_category) { Fabricate(:category_with_definition) }
+  let(:subcategory) { Fabricate(:category_with_definition, parent_category_id: parent_category.id) }
+
   fab!(:user) { Fabricate(:user) }
   fab!(:automation) do
     Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::POST_CREATED_EDITED)
@@ -85,6 +88,36 @@ describe "PostCreatedEdited" do
 
           expect(list.length).to eq(1)
           expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+      end
+
+      context "when restricted to a subcategory" do
+        before do
+          automation.upsert_field!(
+            "restricted_category",
+            "category",
+            { value: subcategory.id },
+            target: "trigger",
+          )
+        end
+
+        it "fires the trigger" do
+          list =
+            capture_contexts do
+              PostCreator.create(user, basic_topic_params.merge({ category: subcategory.id }))
+            end
+
+          expect(list.length).to eq(1)
+          expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+
+        it "does not fire the trigger for the parent" do
+          list =
+            capture_contexts do
+              PostCreator.create(user, basic_topic_params.merge({ category: parent_category.id }))
+            end
+
+          expect(list.length).to eq(0)
         end
       end
 

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -121,6 +121,37 @@ describe "PostCreatedEdited" do
         end
       end
 
+      context "when restricted to a parent category" do
+        before do
+          automation.upsert_field!(
+            "restricted_category",
+            "category",
+            { value: parent_category.id },
+            target: "trigger",
+          )
+        end
+
+        it "fires the trigger for a subcategory" do
+          list =
+            capture_contexts do
+              PostCreator.create(user, basic_topic_params.merge({ category: subcategory.id }))
+            end
+
+          expect(list.length).to eq(1)
+          expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+
+        it "fires the trigger for the parent" do
+          list =
+            capture_contexts do
+              PostCreator.create(user, basic_topic_params.merge({ category: parent_category.id }))
+            end
+
+          expect(list.length).to eq(1)
+          expect(list[0]["kind"]).to eq("post_created_edited")
+        end
+      end
+
       context "when category is not allowed" do
         fab!(:category) { Fabricate(:category) }
 


### PR DESCRIPTION
Previously, the `post_created_edited` and `after_post_cook` triggers did not support subcategories. 

This also ensure that the triggers work the same way for parent categories, i.e. if a parent category is selected, the hook will fire posts assigned to the parent AND on posts assigned to its direct subcategories. 