### PR TITLE
DEV: Fix Zeitwerk reloading error

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,4 @@ DiscourseAutomation::Engine.routes.draw do
   end
 end
 
-Discourse::Application.routes.append { mount ::DiscourseAutomation::Engine, at: "/" }
+Discourse::Application.routes.draw { mount ::DiscourseAutomation::Engine, at: "/" }


### PR DESCRIPTION
Using `.append` can lead to a 'two routes with the same name' error

Reproduced via

```
rails runner 'Rails.application.reloader.reload!'
```