### PR TITLE
FEATURE: add first accepted answer triggerable to user global notice script

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -95,6 +95,8 @@ en:
         doc: When triggering `suspend_user_by_email` with an api call, the endpoint expects a valid `email` to be present in the params sent. `reasons` and `suspend_until (ISO 8601 format)` can also be used to override default fields values.
       user_global_notice_with_stalled_topic:
         doc: When triggered through stalled topic, the topic owner will receive the global notice.
+      user_global_notice_with_first_accepted_solution:
+        doc: When triggered through first accepted solution, the solution author will receive the global notice.
       send_pms_with_api_call:
         doc: When using `send pms` script with `api call` trigger, the `usernames` param of your request will be used to fill the receivers list.
       topic_required_words:

--- a/lib/discourse_automation/scripts/user_global_notice.rb
+++ b/lib/discourse_automation/scripts/user_global_notice.rb
@@ -19,6 +19,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::USER_GLOBAL
   version 1
 
   triggerables [:stalled_topic]
+  triggerables [:first_accepted_solution] if defined?(DiscourseSolved)
 
   placeholder :username
 
@@ -28,6 +29,10 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::USER_GLOBAL
     if context["kind"] == DiscourseAutomation::Triggerable::STALLED_TOPIC
       user = context["topic"].user
       placeholders["username"] = user.username
+    elsif context["kind"] == "first_accepted_solution"
+      username = context["usernames"][0]
+      user = User.find_by(username: username)
+      placeholders["username"] = username
     end
 
     notice = utils.apply_placeholders(fields.dig("notice", "value") || "", placeholders)

--- a/spec/scripts/user_global_notice_spec.rb
+++ b/spec/scripts/user_global_notice_spec.rb
@@ -3,43 +3,104 @@
 require_relative "../discourse_automation_helper"
 
 describe "UserGlobalNotice" do
-  fab!(:automation_1) do
-    Fabricate(
-      :automation,
-      script: DiscourseAutomation::Scriptable::USER_GLOBAL_NOTICE,
-      trigger: "stalled_topic",
-    )
-  end
+  before { SiteSetting.discourse_automation_enabled = true }
 
-  fab!(:topic_1) { Fabricate(:topic) }
+  context "when triggered by a stalled topic" do
+    fab!(:automation_1) do
+      Fabricate(
+        :automation,
+        script: DiscourseAutomation::Scriptable::USER_GLOBAL_NOTICE,
+        trigger: "stalled_topic",
+      )
+    end
 
-  before do
-    SiteSetting.discourse_automation_enabled = true
+    fab!(:topic_1) { Fabricate(:topic) }
 
-    automation_1.upsert_field!("stalled_after", "choices", { value: "PT1H" }, target: "trigger")
-    automation_1.upsert_field!("notice", "message", { value: "foo bar" }, target: "script")
-    automation_1.upsert_field!("level", "choices", { value: "error" }, target: "script")
-  end
+    before do
+      automation_1.upsert_field!("stalled_after", "choices", { value: "PT1H" }, target: "trigger")
+      automation_1.upsert_field!("notice", "message", { value: "foo bar" }, target: "script")
+      automation_1.upsert_field!("level", "choices", { value: "error" }, target: "script")
+    end
 
-  describe "script" do
-    describe "StalledTopic trigger" do
-      it "creates a notice for the topic owner" do
-        expect do
-          automation_1.trigger!(
-            "kind" => DiscourseAutomation::Triggerable::STALLED_TOPIC,
-            "topic" => topic_1,
-          )
-        end.to change { DiscourseAutomation::UserGlobalNotice.count }.by(1)
+    describe "script" do
+      describe "StalledTopic trigger" do
+        it "creates a notice for the topic owner" do
+          expect do
+            automation_1.trigger!(
+              "kind" => DiscourseAutomation::Triggerable::STALLED_TOPIC,
+              "topic" => topic_1,
+            )
+          end.to change { DiscourseAutomation::UserGlobalNotice.count }.by(1)
 
-        user_notice = DiscourseAutomation::UserGlobalNotice.last
-        expect(user_notice.user_id).to eq(topic_1.user_id)
-        expect(user_notice.level).to eq("error")
-        expect(user_notice.notice).to eq("foo bar")
+          user_notice = DiscourseAutomation::UserGlobalNotice.last
+          expect(user_notice.user_id).to eq(topic_1.user_id)
+          expect(user_notice.level).to eq("error")
+          expect(user_notice.notice).to eq("foo bar")
+        end
       end
+    end
+
+    it "creates and destroy global notices" do
+      post = Fabricate(:post, created_at: 1.day.ago)
+
+      expect { Jobs::StalledTopicTracker.new.execute }.to change {
+        DiscourseAutomation::UserGlobalNotice.count
+      }.by(1)
+
+      expect {
+        PostCreator.create!(post.user, topic_id: post.topic_id, raw: "lorem ipsum dolor sit amet")
+      }.to change { DiscourseAutomation::UserGlobalNotice.count }.by(-1)
+    end
+  end
+
+  context "when triggered by a first accepted solution" do
+    fab!(:automation_1) do
+      Fabricate(
+        :automation,
+        script: DiscourseAutomation::Scriptable::USER_GLOBAL_NOTICE,
+        trigger: "first_accepted_solution",
+      )
+    end
+
+    fab!(:user_1) { Fabricate(:user, username: "user_solved_1") }
+    fab!(:post_1) { Fabricate(:post, user: user_1) }
+
+    before do
+      automation_1.upsert_field!(
+        "notice",
+        "message",
+        { value: "notice for %%USERNAME%%" },
+        target: "script",
+      )
+      automation_1.upsert_field!("level", "choices", { value: "success" }, target: "script")
+    end
+
+    it "creates a notice for the solution author" do
+      expect do
+        automation_1.trigger!(
+          "kind" => "first_accepted_solution",
+          "accepted_post_id" => post_1.id,
+          "usernames" => [post_1.user.username],
+          "placeholders" => {
+            "post_url" => Discourse.base_url + post_1.url,
+          },
+        )
+      end.to change { DiscourseAutomation::UserGlobalNotice.count }.by(1)
+
+      user_notice = DiscourseAutomation::UserGlobalNotice.last
+      expect(user_notice.user_id).to eq(post_1.user.id)
+      expect(user_notice.level).to eq("success")
+      expect(user_notice.notice).to eq("notice for user_solved_1")
     end
   end
 
   describe "on_reset" do
+    fab!(:topic_1) { Fabricate(:topic) }
+
+    fab!(:automation_1) do
+      Fabricate(:automation, script: DiscourseAutomation::Scriptable::USER_GLOBAL_NOTICE)
+    end
+
     fab!(:automation_2) do
       Fabricate(:automation, script: DiscourseAutomation::Scriptable::USER_GLOBAL_NOTICE)
     end
@@ -64,17 +125,5 @@ describe "UserGlobalNotice" do
       expect(klass.exists?(identifier: automation_1.id)).to eq(false)
       expect(klass.exists?(identifier: automation_2.id)).to eq(true)
     end
-  end
-
-  it "creates and destroy global notices" do
-    post = Fabricate(:post, created_at: 1.day.ago)
-
-    expect { Jobs::StalledTopicTracker.new.execute }.to change {
-      DiscourseAutomation::UserGlobalNotice.count
-    }.by(1)
-
-    expect {
-      PostCreator.create!(post.user, topic_id: post.topic_id, raw: "lorem ipsum dolor sit amet")
-    }.to change { DiscourseAutomation::UserGlobalNotice.count }.by(-1)
   end
 end


### PR DESCRIPTION
The user global notice script only supported the stalled topic triggerable.

This PR adds the first accepted answer triggerable from `discourse-solved` to the user global notice script if `discourse-solved` is installed.

I've separated the stalled topic triggerable tests to its own context to help clarity.

### Setting up the automation
![image](https://github.com/discourse/discourse-automation/assets/3530/39b34ba2-7a83-4fac-ae87-50079742862d)

### A user global notice
![image](https://github.com/discourse/discourse-automation/assets/3530/51897166-f5bc-4f0c-98a4-9091353dbc8e)
