### PR TITLE
DEV: Avoid constant redefinition warning

### DIFF
--- a/app/jobs/scheduled/discourse_automation_tracker.rb
+++ b/app/jobs/scheduled/discourse_automation_tracker.rb
@@ -4,7 +4,7 @@ module Jobs
   class DiscourseAutomationTracker < ::Jobs::Scheduled
     every 1.minute
 
-    BATCH_LIMIT = 300
+    BATCH_LIMIT ||= 300
 
     def execute(_args = nil)
       return unless SiteSetting.discourse_automation_enabled


### PR DESCRIPTION
This file shouldn't be loaded twice but it is 🥲 I debugged it for a while but could figure it out. Let's just `||=` it.