### PR TITLE
FEATURE: Option to force title and flair updates for badge-group syncs

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -232,6 +232,9 @@ en:
             group:
               label: Group
               description: Target group. Users with the specified badge will be added to this group
+            update_user_title_and_flair:
+              label: Update user title and flair
+              description: Optional, Update user title and flair
             remove_members_without_badge:
               label: Remove existing members without badge
               description: Optional, Remove existing group members without the specified badge


### PR DESCRIPTION
Introduce the option to keep user title and flair updated for each group membership change triggered by `user_group_membership_through_badge` automation.

See  https://github.com/discourse/discourse-automation/pull/206