### PR TITLE
FEATURE: Additional options for pm_created and post_created_edited triggers

### DIFF
--- a/assets/javascripts/discourse/components/fields/da-key-value-field.js
+++ b/assets/javascripts/discourse/components/fields/da-key-value-field.js
@@ -27,6 +27,14 @@ export default class KeyValueField extends BaseField {
     );
   }
 
+  get keyCount() {
+    if (this.get("field.metadata.value")) {
+      return JSON.parse(this.value).length;
+    }
+
+    return 0;
+  }
+
   @action
   handleValueChange(value) {
     if (value !== this.field.metadata.value) {

--- a/assets/javascripts/discourse/templates/components/fields/da-key-value-field.hbs
+++ b/assets/javascripts/discourse/templates/components/fields/da-key-value-field.hbs
@@ -3,10 +3,12 @@
     {{fields/da-field-label label=label field=field}}
 
     <div class="controls">
-      <DButton
-        @label="discourse_automation.fields.key_value.label"
-        @action={{fn (mut this.showJsonEditorModal) true}}
-      />
+      <DButton @action={{fn (mut this.showJsonEditorModal) true}}>
+        {{i18n
+          "discourse_automation.fields.key_value.label"
+          count=this.keyCount
+        }}
+      </DButton>
 
       {{#if this.showJsonEditorModal}}
         <Modal::JsonSchemaEditor

--- a/assets/stylesheets/common/discourse-automation.scss
+++ b/assets/stylesheets/common/discourse-automation.scss
@@ -78,6 +78,12 @@
     .controls {
       margin-left: 185px;
     }
+
+    .boolean-field {
+      .controls {
+        display: flex;
+      }
+    }
   }
 
   .automation-presentation {

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -21,7 +21,10 @@ en:
         confirm: "Are you sure you want to delete `%{name}`?"
       fields:
         key_value:
-          label: Configure
+          label:
+            zero: Configure
+            one: Edit Configuration (%{count})
+            other: Edit Configuration (%{count})
         user:
           label: User
         pm:
@@ -143,7 +146,16 @@ en:
               description: Will trigger only if post is created by user in these trust levels, defaults to any trust level
             restricted_category:
               label: Category
-              description: Optional, allows to limit trigger execution to this category
+              description: Optional, will trigger only if the post's topic is in this category
+            restricted_group:
+              label: Group
+              description: Optional, will trigger only if the post's topic is a private message in this group's inbox
+            ignore_group_members:
+              label: Ignore group members
+              description: Skip the trigger if sender is a member of the Group specified above
+            ignore_automated:
+              label: Ignore automated
+              description: Skip the trigger if the sender has a noreply email or is from an automated source. Only applies to posts created via email
           created: Created
           edited: Edited
         category_created_edited:
@@ -154,11 +166,20 @@ en:
         pm_created:
           fields:
             restricted_user:
-              label: User
-              description: Allows to limit trigger execution to this user
+              label: Users
+              description: Will trigger only for PMs sent to this user
+            restricted_group:
+              label: Group
+              description: Will trigger only for PMs sent to this group
             ignore_staff:
               label: Ignore staff
               description: Skip the trigger if sender is a staff user
+            ignore_group_members:
+              label: Ignore group members
+              description: Skip the trigger if sender is a member of the Group specified above
+            ignore_automated:
+              label: Ignore automated
+              description: Skip the trigger if the sender has a noreply email or is from an automated source. Only applies to PMs created via email
             valid_trust_levels:
               label: Valid trust levels
               description: Will trigger only if post is created by user in these trust levels, defaults to any trust level
@@ -169,10 +190,10 @@ en:
               description: Will trigger only if post is created by user in these trust levels, defaults to any trust level
             restricted_category:
               label: Category
-              description: Optional, allows to limit trigger execution to this category
+              description: Optional, will trigger only if the post's topic is in this category
             restricted_tags:
               label: Tags
-              description: Optional, allows to limit trigger execution to any of these tags
+              description: Optional, will trigger only if the post has any of these tags
       scriptables:
         not_found: Couldn’t find script `%{script}` for automation `%{automation}`, ensure the associated plugin is installed
         zapier_webhook:
@@ -187,7 +208,7 @@ en:
               description: Only responds once by topic
             word_answer_list:
               label: List of word/answer pairs
-              description: "Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. Note that `value` accepts `%%KEY%%` as a placeholder to be replaced by the value of `key` in the reply. Note that `key` will be evaluated as a regex, and special chars like `.` should be escaped if you actually mean a dot, eg: `\\.`"
+              description: "Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. The `key` can be left blank to respond to all triggers, regardless of content. Note that `value` accepts `%%KEY%%` as a placeholder to be replaced by the value of `key` in the reply. Note that `key` will be evaluated as a regex, and special chars like `.` should be escaped if you actually mean a dot, eg: `\\.`"
             answering_user:
               label: Answering user
               description: Defaults to System user

--- a/lib/discourse_automation/scripts/auto_responder.rb
+++ b/lib/discourse_automation/scripts/auto_responder.rb
@@ -26,29 +26,29 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_RESPON
     next if fields.dig("once", "value") && post.topic.custom_fields[key]&.include?(automation.id)
 
     answers = Set.new
-    json = fields.dig("word_answer_list", "value")
-    next if json.blank?
+    word_answer_list_json = fields.dig("word_answer_list", "value")
+    next if word_answer_list_json.blank?
 
-    tuples = JSON.parse(json)
-    next if tuples.blank?
+    word_answer_list = JSON.parse(word_answer_list_json)
+    next if word_answer_list.blank?
 
-    tuples.each do |tuple|
-      if tuple["key"].blank?
-        answers.add(tuple)
+    word_answer_list.each do |word_answer_pair|
+      if word_answer_pair["key"].blank?
+        answers.add(word_answer_pair)
         next
       end
 
       if post.is_first_post?
-        if match = post.topic.title.match(/\b(#{tuple["key"]})\b/i)
-          tuple["key"] = match.captures.first
-          answers.add(tuple)
+        if match = post.topic.title.match(/\b(#{word_answer_pair["key"]})\b/i)
+          word_answer_pair["key"] = match.captures.first
+          answers.add(word_answer_pair)
           next
         end
       end
 
-      if match = post.raw.match(/\b(#{tuple["key"]})\b/i)
-        tuple["key"] = match.captures.first
-        answers.add(tuple)
+      if match = post.raw.match(/\b(#{word_answer_pair["key"]})\b/i)
+        word_answer_pair["key"] = match.captures.first
+        answers.add(word_answer_pair)
       end
     end
 

--- a/lib/discourse_automation/triggers/pm_created.rb
+++ b/lib/discourse_automation/triggers/pm_created.rb
@@ -4,6 +4,9 @@ DiscourseAutomation::Triggerable::PM_CREATED = "pm_created"
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::PM_CREATED) do
   field :restricted_user, component: :user
+  field :restricted_group, component: :group
   field :ignore_staff, component: :boolean
+  field :ignore_automated, component: :boolean
+  field :ignore_group_members, component: :boolean
   field :valid_trust_levels, component: :"trust-levels"
 end

--- a/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/lib/discourse_automation/triggers/post_created_edited.rb
@@ -10,5 +10,8 @@ ACTION_TYPE_CHOICES = [
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::POST_CREATED_EDITED) do
   field :action_type, component: :choices, extra: { content: ACTION_TYPE_CHOICES }
   field :restricted_category, component: :category
+  field :restricted_group, component: :group
+  field :ignore_automated, component: :boolean
+  field :ignore_group_members, component: :boolean
   field :valid_trust_levels, component: :"trust-levels"
 end

--- a/spec/scripts/auto_responder_spec.rb
+++ b/spec/scripts/auto_responder_spec.rb
@@ -60,6 +60,24 @@ describe "AutoResponder" do
           expect(topic.reload.posts.last.raw).to eq("this is foo")
         end
       end
+
+      context "when the word answer list has a wildcard (empty string) for key" do
+        before do
+          automation.upsert_field!(
+            "word_answer_list",
+            "key-value",
+            { value: [{ key: "", value: "this is a response" }].to_json },
+          )
+        end
+
+        it "creates an answer" do
+          topic = Fabricate(:topic, title: "What a foo day to walk")
+          post = create_post(topic: topic, raw: "this is a post with no keyword")
+          automation.trigger!("post" => post)
+
+          expect(topic.reload.posts.last.raw).to eq("this is a response")
+        end
+      end
     end
 
     context "when post contains a keyword" do


### PR DESCRIPTION
This commit introduces some additional options to make the
pm_created and post_created_edited triggers more useable as
auto-responders inside group inboxes.

* restricted_group - Will only call the trigger if the topic is a PM
sent to the specified group.
* ignore_automated - If the post/topic is being created from an incoming
email, and it is from a noreply address or otherwise automated, then it
will not be considered valid for the autoresponder to reply to.
* ignore_group_members - When combined with restricted_group, the
autoresponder will not fire the trigger if the post/topic is being
created by a member of the group.

This commit also does some minor refactors and makes some UI
and copy improvements.

![image](https://github.com/discourse/discourse-automation/assets/920448/37198f8d-d3c0-4303-9286-4cdb967d35f5)

Needs https://github.com/discourse/discourse/pull/23364