### PR TITLE
FIX: I18n lookup locale

### DIFF
--- a/assets/javascripts/discourse/components/automation-field.js
+++ b/assets/javascripts/discourse/components/automation-field.js
@@ -29,10 +29,12 @@ export default class AutomationField extends Component {
   }
 
   @computed("target", "field.name")
+  get translationKey() {
+    return `discourse_automation${this.target}fields.${this.field.name}.description`;
+  }
+
+  @computed("target", "field.name")
   get description() {
-    return I18n.lookup(
-      `discourse_automation${this.target}fields.${this.field.name}.description`,
-      { locale: I18n.locale }
-    );
+    return I18n.t(this.translationKey);
   }
 }


### PR DESCRIPTION
The locale option is not necessary when calling I18n.lookup,
and furthermore this was making the description for fields not
show if using an untranslated locale, rather than just falling
back to en-US.
