### PR TITLE
FIX: Post created event issue when group specified

### DIFF
--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -28,10 +28,12 @@ module DiscourseAutomation
             next if !category_ids.include?(restricted_category["value"])
           end
 
-          if topic.private_message?
+          restricted_group_id = automation.trigger_field("restricted_group")["value"]
+          if restricted_group_id.present?
+            next if !topic.private_message?
+
             target_group_ids = topic.allowed_groups.pluck(:id)
-            restricted_group_id = automation.trigger_field("restricted_group")["value"]
-            next if restricted_group_id.present? && restricted_group_id != target_group_ids.first
+            next if restricted_group_id != target_group_ids.first
 
             ignore_group_members = automation.trigger_field("ignore_group_members")
             next if ignore_group_members["value"] && post.user.in_any_groups?([restricted_group_id])
@@ -47,6 +49,7 @@ module DiscourseAutomation
             next if selected_action == :created && action != :create
             next if selected_action == :edited && action != :edit
           end
+
           automation.trigger!("kind" => name, "action" => action, "post" => post)
         end
     end

--- a/spec/triggers/post_created_edited_spec.rb
+++ b/spec/triggers/post_created_edited_spec.rb
@@ -97,6 +97,18 @@ describe "PostCreatedEdited" do
         expect(list[0]["kind"]).to eq("post_created_edited")
       end
 
+      context "when the topic is not a PM" do
+        it "doesn’t fire the trigger" do
+          list =
+            capture_contexts do
+              user.groups << target_group
+              PostCreator.create(user, basic_topic_params)
+            end
+
+          expect(list).to be_blank
+        end
+      end
+
       context "when members of the group are ignored" do
         before do
           automation.upsert_field!(


### PR DESCRIPTION
When a restricted_group was specified for a post_created_edited
trigger, we were only checking for the group validity if the topic
was a PM. However, we weren't handling the opposite case -- if the
topic is a public topic and there is a restricted_group, then we
want to skip the trigger, since the group param is only meant to work
with group inboxes.
