### PR TITLE
DEV: allows to ignore automatic groups from group component

### DIFF
--- a/assets/javascripts/discourse/components/fields/da-group-field.js
+++ b/assets/javascripts/discourse/components/fields/da-group-field.js
@@ -8,7 +8,9 @@ export default class GroupField extends BaseField {
   init() {
     super.init(...arguments);
 
-    Group.findAll().then((groups) => {
+    Group.findAll({
+      ignore_automatic: this.field.extra.ignore_automatic ?? false,
+    }).then((groups) => {
       if (this.isDestroying || this.isDestroyed) {
         return;
       }

--- a/lib/discourse_automation/scripts/user_group_membership_through_badge.rb
+++ b/lib/discourse_automation/scripts/user_group_membership_through_badge.rb
@@ -10,7 +10,7 @@ DiscourseAutomation::Scriptable.add(
   version 1
 
   field :badge_name, component: :text, required: true
-  field :group, component: :group, required: true
+  field :group, component: :group, required: true, extra: { ignore_automatic: true }
   field :update_user_title_and_flair, component: :boolean
   field :remove_members_without_badge, component: :boolean
 


### PR DESCRIPTION
This is now only used in `USER_GROUP_MEMBERSHIP_THROUGH_BADGE` script and `false` by default.