### PR TITLE
UX: do not show implicit placeholders

### DIFF
--- a/app/serializers/discourse_automation/automation_serializer.rb
+++ b/app/serializers/discourse_automation/automation_serializer.rb
@@ -28,7 +28,7 @@ module DiscourseAutomation
     end
 
     def placeholders
-      (scriptable.placeholders || []) + (triggerable.placeholders || []) + ["report=report_name"]
+      (scriptable.placeholders || []) + (triggerable.placeholders || [])
     end
 
     def script

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -21,7 +21,7 @@ module DiscourseAutomation
       @name = name
       @version = 0
       @fields = []
-      @placeholders = [:site_title]
+      @placeholders = []
       @triggerables = (@@plugin_triggerables[name&.to_sym] || [])
       @script = proc {}
       @on_reset = proc {}
@@ -153,7 +153,7 @@ module DiscourseAutomation
         table
       end
 
-      def self.apply_placeholders(input, map)
+      def self.apply_placeholders(input, map = {})
         input = input.dup
         map[:site_title] = SiteSetting.title
 

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -86,7 +86,7 @@ describe DiscourseAutomation::Scriptable do
 
   describe "#placeholders" do
     it "returns the specified placeholders" do
-      expect(automation.scriptable.placeholders).to eq(%i[site_title foo bar])
+      expect(automation.scriptable.placeholders).to eq(%i[foo bar])
     end
   end
 
@@ -158,6 +158,12 @@ describe DiscourseAutomation::Scriptable do
         map = { cool_cat: "siberian cat" }
         output = automation.scriptable.utils.apply_placeholders(input, map)
         expect(output).to eq("hello siberian cat")
+      end
+
+      it "replaces site_title by default" do
+        input = "hello %%SITE_TITLE%%"
+        output = automation.scriptable.utils.apply_placeholders(input)
+        expect(output).to eq("hello #{SiteSetting.title}")
       end
 
       context "when using the REPORT key" do


### PR DESCRIPTION
Only explicit placeholders defined with the `placeholder` syntax will be shown under fields. `%%SITE_TITLE%%` and `%%REPORT=report_name%%` will keep working but the buttons to add them won't be displayed by default under each field.