### PR TITLE
FEATURE: allow User Custom Field input field to accept the UserField name

### DIFF
--- a/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
+++ b/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
@@ -23,14 +23,14 @@ DiscourseAutomation::Scriptable.add(
 
     case trigger["kind"]
     when DiscourseAutomation::Triggerable::API_CALL, DiscourseAutomation::Triggerable::RECURRING
-      query = DB.query(<<-SQL, custom_field_name: custom_field_name)
+      query = DB.query(<<-SQL, custom_field_name: custom_field_name, prefix: ::User::USER_FIELD_PREFIX)
         SELECT u.id as user_id, g.id as group_id
         FROM users u
         JOIN user_custom_fields ucf
           ON u.id = ucf.user_id
           AND ucf.name = CASE
                              WHEN (SELECT id FROM user_fields WHERE name = :custom_field_name) > 0
-                                 THEN CONCAT('user_field_', (SELECT id FROM user_fields WHERE name = :custom_field_name))
+                                 THEN CONCAT(:prefix, (SELECT id FROM user_fields WHERE name = :custom_field_name))
                              ELSE :custom_field_name
                          END
         JOIN groups g

--- a/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
+++ b/lib/discourse_automation/scripts/add_user_to_group_through_custom_field.rb
@@ -23,14 +23,18 @@ DiscourseAutomation::Scriptable.add(
 
     case trigger["kind"]
     when DiscourseAutomation::Triggerable::API_CALL, DiscourseAutomation::Triggerable::RECURRING
-      query = DB.query(<<-SQL, custom_field_name)
+      query = DB.query(<<-SQL, custom_field_name: custom_field_name)
         SELECT u.id as user_id, g.id as group_id
         FROM users u
         JOIN user_custom_fields ucf
           ON u.id = ucf.user_id
-          AND ucf.name = ?
+          AND ucf.name = CASE
+                             WHEN (SELECT id FROM user_fields WHERE name = :custom_field_name) > 0
+                                 THEN CONCAT('user_field_', (SELECT id FROM user_fields WHERE name = :custom_field_name))
+                             ELSE :custom_field_name
+                         END
         JOIN groups g
-          on g.full_name ilike ucf.value
+          ON g.full_name ilike ucf.value
         FULL OUTER JOIN group_users gu
           ON gu.user_id = u.id
           AND gu.group_id = g.id

--- a/spec/scripts/add_user_to_group_through_custom_field_spec.rb
+++ b/spec/scripts/add_user_to_group_through_custom_field_spec.rb
@@ -37,9 +37,14 @@ describe "AddUserTogroupThroughCustomField" do
 
   context "with one matching user" do
     before do
+      user_field = UserField.create!(
+        name: "groupity_group",
+        description: "What group would you like to be added to?",
+        field_type: "text",
+      )
       UserCustomField.create!(
         user_id: user_1.id,
-        name: "groupity_group",
+        name: "user_field_#{user_field.id}",
         value: target_group.full_name,
       )
     end


### PR DESCRIPTION
Currently the `add_user_to_group_through_custom_field` script expects the UserCustomField name to be used when the automation is triggered with the "Recurring" trigger, and the UserField name to be used when the automation is triggered by the "User first logged in" trigger. This is confusing for users. For both triggers, it would be better if the UserField name could be used. That's the name that is displayed on the Admin / Customize / User Fields page.

This PR attempts to fix the issue in a backwards compatible way, so that existing automations that are making use of the UserCustomField name (for example: 'user_field_5') will not be broken.

The PR also updates the "with one matching user" test to set the UserCustomField name in the way that Discourse sets the name - based on the UserField's id.

Related discussion on Meta: https://meta.discourse.org/t/add-user-to-group-script-has-different-field-input-for-the-two-triggers/281813