### PR TITLE
DEV: Change user_group_membership_through_badge's badge_name field

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -265,6 +265,9 @@ en:
             remove_members_without_badge:
               label: Remove existing members without badge
               description: Optional, Remove existing group members without the specified badge
+            badge:
+              label: Badge
+              description: Select badge
         suspend_user_by_email:
           fields:
             suspend_until:

--- a/db/migrate/20231017175757_change_user_group_membership_through_badge_script_badge_name_field_to_badge.rb
+++ b/db/migrate/20231017175757_change_user_group_membership_through_badge_script_badge_name_field_to_badge.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+class ChangeUserGroupMembershipThroughBadgeScriptBadgeNameFieldToBadge < ActiveRecord::Migration[
+  7.0
+]
+  def change
+    query = <<~SQL
+      SELECT
+        f.id,
+        b.id AS badge_id
+      FROM
+        discourse_automation_fields f
+      INNER JOIN  discourse_automation_automations a ON a.id = f.automation_id
+      INNER JOIN badges b ON b.name = TRIM(BOTH ' ' FROM f.metadata->>'value')
+      WHERE
+        f.name = 'badge_name'
+        AND  a.script = 'user_group_membership_through_badge'
+    SQL
+
+    DB
+      .query(query)
+      .each do |field|
+        metadata = { value: field.badge_id }.to_json
+
+        DB.exec(<<~SQL, field_id: field.id, metadata: metadata)
+        UPDATE discourse_automation_fields
+        SET metadata = :metadata, component = 'choices', name = 'badge'
+        WHERE id = :field_id
+      SQL
+      end
+  end
+end

--- a/spec/scripts/user_group_membership_through_badge_spec.rb
+++ b/spec/scripts/user_group_membership_through_badge_spec.rb
@@ -38,15 +38,10 @@ describe "UserGroupMembershipThroughBadge" do
     after { Rails.logger = @original_logger }
 
     context "with an unknown badge" do
-      let(:unknown_badge_name) { "Unknown Badge" }
+      let(:unknown_badge_id) { -1 }
 
       before do
-        automation.upsert_field!(
-          "badge_name",
-          "text",
-          { value: unknown_badge_name },
-          target: "script",
-        )
+        automation.upsert_field!("badge", "choices", { value: unknown_badge_id }, target: "script")
         automation.trigger!(
           "kind" => DiscourseAutomation::Triggerable::USER_FIRST_LOGGED_IN,
           "user" => user,
@@ -55,7 +50,7 @@ describe "UserGroupMembershipThroughBadge" do
 
       it "logs warning message and does nothing" do
         expect(@fake_logger.warnings).to include(
-          "[discourse-automation] Couldn’t find badge with name #{unknown_badge_name}",
+          "[discourse-automation] Couldn’t find badge with id #{unknown_badge_id}",
         )
         expect(user.reload.groups).to be_empty
       end
@@ -63,7 +58,7 @@ describe "UserGroupMembershipThroughBadge" do
 
     context "with a non-existent group" do
       before do
-        automation.upsert_field!("badge_name", "text", { value: badge.name }, target: "script")
+        automation.upsert_field!("badge", "choices", { value: badge.id }, target: "script")
         automation.upsert_field!("group", "group", { value: target_group.id }, target: "script")
       end
 
@@ -85,7 +80,7 @@ describe "UserGroupMembershipThroughBadge" do
 
   context "with valid field values" do
     before do
-      automation.upsert_field!("badge_name", "text", { value: badge.name }, target: "script")
+      automation.upsert_field!("badge", "choices", { value: badge.id }, target: "script")
       automation.upsert_field!("group", "group", { value: target_group.id }, target: "script")
     end
 

--- a/spec/system/smoke_test_spec.rb
+++ b/spec/system/smoke_test_spec.rb
@@ -5,6 +5,7 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
 
   before do
     Fabricate(:group, name: "test")
+    Fabricate(:badge, name: "badge")
     SiteSetting.discourse_automation_enabled = true
     sign_in(admin)
   end
@@ -21,7 +22,9 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
     select_kit = PageObjects::Components::SelectKit.new(".triggerables")
     select_kit.expand
     select_kit.select_row_by_value("user_first_logged_in")
-    fill_in("badge_name", with: "test")
+    select_kit = PageObjects::Components::SelectKit.new(".fields-section .combo-box")
+    select_kit.expand
+    select_kit.select_row_by_name("badge")
     select_kit = PageObjects::Components::SelectKit.new(".group-chooser")
     select_kit.expand
     select_kit.select_row_by_name("test")


### PR DESCRIPTION
This changes the `badge_name` script field to `badge` and component type from free form text to dropdown

### Before
<img width="796" alt="Screenshot 2023-10-18 at 12 42 08 PM" src="https://github.com/discourse/discourse-automation/assets/849886/719df5d4-a3e7-424e-b082-5dc4d0c2c54d">


### After
<img width="689" alt="Screenshot 2023-10-18 at 12 39 51 PM" src="https://github.com/discourse/discourse-automation/assets/849886/61296f6a-003d-47ec-9ff5-04d2c7442ce9">

