### PR TITLE
DEV: Resolve registerUnbound deprecation

### DIFF
--- a/assets/javascripts/discourse/helpers/format-delay.js
+++ b/assets/javascripts/discourse/helpers/format-delay.js
@@ -1,7 +1,0 @@
-import { registerUnbound } from "discourse-common/lib/helpers";
-
-registerUnbound("format-delay", function (minutes) {
-  return minutes
-    ? moment.duration(parseInt(minutes, 10), "minutes").humanize()
-    : "-";
-});

--- a/assets/javascripts/discourse/helpers/format-enabled-automation.js
+++ b/assets/javascripts/discourse/helpers/format-enabled-automation.js
@@ -1,8 +1,7 @@
 import { iconHTML } from "discourse-common/lib/icon-library";
-import { registerUnbound } from "discourse-common/lib/helpers";
 import { htmlSafe } from "@ember/template";
 
-registerUnbound("format-enabled-automation", function (enabled, trigger) {
+export default function formatEnabledAutomation(enabled, trigger) {
   if (enabled && trigger.id) {
     return htmlSafe(
       iconHTML("check", {
@@ -18,4 +17,4 @@ registerUnbound("format-enabled-automation", function (enabled, trigger) {
       })
     );
   }
-});
+}


### PR DESCRIPTION
- Deletes unused format-delay helper
- Updates format-enabled-automation helper to be a default export