### PR TITLE
FIX: Always run automations in background when triggered via API

### DIFF
--- a/app/controllers/discourse_automation/automations_controller.rb
+++ b/app/controllers/discourse_automation/automations_controller.rb
@@ -7,7 +7,9 @@ module DiscourseAutomation
 
     def trigger
       automation = DiscourseAutomation::Automation.find(params[:id])
-      automation.trigger!(params.merge(kind: DiscourseAutomation::Triggerable::API_CALL))
+      automation.trigger_in_background!(
+        params.merge(kind: DiscourseAutomation::Triggerable::API_CALL),
+      )
       render json: success_json
     end
   end

--- a/spec/requests/discourse_automation_automations_spec.rb
+++ b/spec/requests/discourse_automation_automations_spec.rb
@@ -20,7 +20,10 @@ describe DiscourseAutomation::AdminAutomationsController do
 
       context "when user is logged in" do
         context "when user is admin" do
-          before { sign_in(Fabricate(:admin)) }
+          before do
+            Jobs.run_immediately!
+            sign_in(Fabricate(:admin))
+          end
 
           it "triggers the automation" do
             list = capture_contexts { post "/automations/#{automation.id}/trigger.json" }
@@ -67,6 +70,7 @@ describe DiscourseAutomation::AdminAutomationsController do
                }
 
           expect(response.status).to eq(200)
+          expect(Jobs::DiscourseAutomationTrigger.jobs.size).to eq(1)
         end
       end
     end
@@ -75,7 +79,10 @@ describe DiscourseAutomation::AdminAutomationsController do
       fab!(:admin) { Fabricate(:admin) }
       fab!(:automation) { Fabricate(:automation, trigger: "api_call") }
 
-      before { sign_in(admin) }
+      before do
+        Jobs.run_immediately!
+        sign_in(admin)
+      end
 
       it "passes the params" do
         list =


### PR DESCRIPTION
Currently, long running automations lead to timeouts.

This change moves automation trigger to the background instead of running it in the web process.