### PR TITLE
UX: Throw an error when PM creation fails

### DIFF
--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -220,7 +220,7 @@ module DiscourseAutomation
               post_created = EncryptedPostCreator.new(sender, pm).create
             end
 
-            PostCreator.new(sender, pm).create if !post_created
+            PostCreator.new(sender, pm).create! if !post_created
           else
             Rails.logger.warn "[discourse-automation] Couldn’t send PM to user with username: `#{sender}`."
           end

--- a/spec/jobs/discourse_automation_tracker_spec.rb
+++ b/spec/jobs/discourse_automation_tracker_spec.rb
@@ -78,6 +78,7 @@ describe Jobs::DiscourseAutomationTracker do
         raw: "Quelle est cette langueur Qui pénètre mon cœur ?",
         sender: "system",
         execute_at: Time.now,
+        target_usernames: ["system"],
       )
     end
 

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -249,7 +249,7 @@ describe DiscourseAutomation::Scriptable do
               {
                 title: "Tell me and I forget.",
                 raw: "0123456789" * 25 + "a",
-                target_usernames: Array(user.username),
+                target_usernames: [user.username],
               },
             )
           }.to raise_error(ActiveRecord::RecordNotSaved)

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -239,6 +239,22 @@ describe DiscourseAutomation::Scriptable do
           }.to change { Post.count }.by(1)
         end
       end
+
+      context "when pm exceeds max_post_length" do
+        it "throws an error" do
+          SiteSetting.max_post_length = 250
+
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Tell me and I forget.",
+                raw: "0123456789" * 25 + "a",
+                target_usernames: Array(user.username),
+              },
+            )
+          }.to raise_error(ActiveRecord::RecordNotSaved)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
In another plugin that is using the Send PM feature (discourse-data-explorer), when a PM is sent that violates `SiteSetting.max_post_length`, there is no indication that the PM did not send.

Raising an error here can help surface that.