### PR TITLE
DEV: eslint fixes to imports and property order

### DIFF
--- a/assets/javascripts/discourse/components/fields/da-boolean-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-boolean-field.gjs
@@ -1,9 +1,9 @@
-import BaseField from "./da-base-field";
 import { Input } from "@ember/component";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import { action } from "@ember/object";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class BooleanField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-categories-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-categories-field.gjs
@@ -1,10 +1,10 @@
-import Category from "discourse/models/category";
-import { action } from "@ember/object";
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import CategorySelector from "select-kit/components/category-selector";
 import { fn, hash } from "@ember/helper";
+import { action } from "@ember/object";
+import Category from "discourse/models/category";
+import CategorySelector from "select-kit/components/category-selector";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class CategoriesField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-category-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-category-field.gjs
@@ -1,8 +1,8 @@
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import CategoryChooser from "select-kit/components/category-chooser";
 import { hash } from "@ember/helper";
+import CategoryChooser from "select-kit/components/category-chooser";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class CategoryField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-category-notification-level-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-category-notification-level-field.gjs
@@ -1,8 +1,8 @@
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import CategoryNotificationsButton from "select-kit/components/category-notifications-button";
 import { hash } from "@ember/helper";
+import CategoryNotificationsButton from "select-kit/components/category-notifications-button";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class CategoryNotficationLevelField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-choices-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-choices-field.gjs
@@ -1,10 +1,9 @@
-import I18n from "I18n";
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import ComboBox from "select-kit/components/combo-box";
 import { hash } from "@ember/helper";
-import { action } from "@ember/object";
+import I18n from "I18n";
+import ComboBox from "select-kit/components/combo-box";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class ChoicesField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-custom-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-custom-field.gjs
@@ -1,15 +1,16 @@
-import BaseField from "./da-base-field";
-import { action } from "@ember/object";
-import { bind } from "discourse-common/utils/decorators";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { tracked } from "@glimmer/tracking";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import ComboBox from "select-kit/components/combo-box";
-import { hash } from "@ember/helper";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { inject as service } from "@ember/service";
+import { bind } from "discourse-common/utils/decorators";
+import ComboBox from "select-kit/components/combo-box";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class GroupField extends BaseField {
+  @service store;
+  @tracked allCustomFields = [];
+
   <template>
     <section class="field group-field" {{didInsert this.loadUserFields}}>
       <div class="control-group">
@@ -26,9 +27,6 @@ export default class GroupField extends BaseField {
       </div>
     </section>
   </template>
-
-  @service store;
-  @tracked allCustomFields = [];
 
   @bind
   loadUserFields() {

--- a/assets/javascripts/discourse/components/fields/da-date-time-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-date-time-field.gjs
@@ -1,10 +1,10 @@
-import BaseField from "./da-base-field";
-import { action } from "@ember/object";
 import { Input } from "@ember/component";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import DButton from "discourse/components/d-button";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import DButton from "discourse/components/d-button";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class DateTimeField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-email-group-user-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-email-group-user-field.gjs
@@ -1,12 +1,15 @@
-import BaseField from "./da-base-field";
+import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import { action } from "@ember/object";
 import EmailGroupUserChooser from "select-kit/components/email-group-user-chooser";
-import DAFieldLabel from "./da-field-label";
+import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
-import { hash } from "@ember/helper";
-import { tracked } from "@glimmer/tracking";
+import DAFieldLabel from "./da-field-label";
 
 export default class EmailGroupUserField extends BaseField {
+  @tracked recipients;
+  @tracked groups = [];
+
   <template>
     <section class="field email-group-user-field">
       <div class="control-group">
@@ -30,9 +33,6 @@ export default class EmailGroupUserField extends BaseField {
       </div>
     </section>
   </template>
-
-  @tracked recipients;
-  @tracked groups = [];
 
   @action
   updateRecipients(selected, content) {

--- a/assets/javascripts/discourse/components/fields/da-group-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-group-field.gjs
@@ -1,13 +1,15 @@
-import BaseField from "./da-base-field";
-import Group from "discourse/models/group";
-import { action } from "@ember/object";
 import { tracked } from "@glimmer/tracking";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import GroupChooser from "select-kit/components/group-chooser";
 import { hash } from "@ember/helper";
+import { action } from "@ember/object";
+import Group from "discourse/models/group";
+import GroupChooser from "select-kit/components/group-chooser";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class GroupField extends BaseField {
+  @tracked allGroups = [];
+
   <template>
     <section class="field group-field">
       <div class="control-group">
@@ -27,8 +29,6 @@ export default class GroupField extends BaseField {
       </div>
     </section>
   </template>
-
-  @tracked allGroups = [];
 
   constructor() {
     super(...arguments);

--- a/assets/javascripts/discourse/components/fields/da-key-value-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-key-value-field.gjs
@@ -1,14 +1,33 @@
-import BaseField from "./da-base-field";
-import { action } from "@ember/object";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import DButton from "discourse/components/d-button";
-import { fn } from "@ember/helper";
-import I18n from "I18n";
-import ModalJsonSchemaEditor from "discourse/components/modal/json-schema-editor";
 import { tracked } from "@glimmer/tracking";
+import { action } from "@ember/object";
+import DButton from "discourse/components/d-button";
+import ModalJsonSchemaEditor from "discourse/components/modal/json-schema-editor";
+import I18n from "I18n";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class KeyValueField extends BaseField {
+  @tracked showJsonEditorModal = false;
+
+  jsonSchema = {
+    type: "array",
+    uniqueItems: true,
+    items: {
+      type: "object",
+      title: "group",
+      properties: {
+        key: {
+          type: "string",
+        },
+        value: {
+          type: "string",
+          format: "textarea",
+        },
+      },
+    },
+  };
+
   <template>
     <section class="field key-value-field">
       <div class="control-group">
@@ -34,26 +53,6 @@ export default class KeyValueField extends BaseField {
       </div>
     </section>
   </template>
-
-  @tracked showJsonEditorModal = false;
-
-  jsonSchema = {
-    type: "array",
-    uniqueItems: true,
-    items: {
-      type: "object",
-      title: "group",
-      properties: {
-        key: {
-          type: "string",
-        },
-        value: {
-          type: "string",
-          format: "textarea",
-        },
-      },
-    },
-  };
 
   get value() {
     return (

--- a/assets/javascripts/discourse/components/fields/da-message-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-message-field.gjs
@@ -1,9 +1,9 @@
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import { TextArea } from "@ember/legacy-built-in-components";
-import PlaceholdersList from "../placeholders-list";
 import { action } from "@ember/object";
+import PlaceholdersList from "../placeholders-list";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class MessageField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-period-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-period-field.gjs
@@ -1,13 +1,13 @@
-import I18n from "I18n";
-import BaseField from "./da-base-field";
-import ComboBox from "select-kit/components/combo-box";
 import { Input } from "@ember/component";
-import { action } from "@ember/object";
 import { hash } from "@ember/helper";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
+import I18n from "I18n";
+import ComboBox from "select-kit/components/combo-box";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class PeriodField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-pms-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-pms-field.gjs
@@ -1,18 +1,32 @@
-import BaseField from "./da-base-field";
-import I18n from "I18n";
-import { action } from "@ember/object";
-import { inject as service } from "@ember/service";
-import { concat, fn } from "@ember/helper";
-import DAFieldLabel from "./da-field-label";
-import DButton from "discourse/components/d-button";
 import { Input } from "@ember/component";
-import PlaceholdersList from "../placeholders-list";
-import DEditor from "discourse/components/d-editor";
+import { concat, fn } from "@ember/helper";
 import { on } from "@ember/modifier";
-import { TrackedArray, TrackedObject } from "@ember-compat/tracked-built-ins";
+import { action } from "@ember/object";
 import { next } from "@ember/runloop";
+import { inject as service } from "@ember/service";
+import { TrackedArray, TrackedObject } from "@ember-compat/tracked-built-ins";
+import DButton from "discourse/components/d-button";
+import DEditor from "discourse/components/d-editor";
+import I18n from "I18n";
+import PlaceholdersList from "../placeholders-list";
+import BaseField from "./da-base-field";
+import DAFieldLabel from "./da-field-label";
 
 export default class PmsField extends BaseField {
+  @service dialog;
+
+  noPmCreatedLabel = I18n.t("discourse_automation.fields.pms.no_pm_created");
+
+  prefersEncryptLabel = I18n.t(
+    "discourse_automation.fields.pms.prefers_encrypt.label"
+  );
+
+  delayLabel = I18n.t("discourse_automation.fields.pms.delay.label");
+
+  pmTitleLabel = I18n.t("discourse_automation.fields.pms.title.label");
+
+  rawLabel = I18n.t("discourse_automation.fields.pms.raw.label");
+
   <template>
     <section class="field pms-field">
       {{#if @field.metadata.value.length}}
@@ -122,20 +136,6 @@ export default class PmsField extends BaseField {
       {{/each}}
     </section>
   </template>
-
-  @service dialog;
-
-  noPmCreatedLabel = I18n.t("discourse_automation.fields.pms.no_pm_created");
-
-  prefersEncryptLabel = I18n.t(
-    "discourse_automation.fields.pms.prefers_encrypt.label"
-  );
-
-  delayLabel = I18n.t("discourse_automation.fields.pms.delay.label");
-
-  pmTitleLabel = I18n.t("discourse_automation.fields.pms.title.label");
-
-  rawLabel = I18n.t("discourse_automation.fields.pms.raw.label");
 
   constructor() {
     super(...arguments);

--- a/assets/javascripts/discourse/components/fields/da-post-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-post-field.gjs
@@ -1,8 +1,8 @@
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
-import PlaceholdersList from "../placeholders-list";
 import DEditor from "discourse/components/d-editor";
+import PlaceholdersList from "../placeholders-list";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class PostField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-tags-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-tags-field.gjs
@@ -1,8 +1,8 @@
-import BaseField from "./da-base-field";
 import { hash } from "@ember/helper";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import TagChooser from "select-kit/components/tag-chooser";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class TagsField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-text-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-text-field.gjs
@@ -1,10 +1,10 @@
-import BaseField from "./da-base-field";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import { Input } from "@ember/component";
-import PlaceholdersList from "../placeholders-list";
-import { action } from "@ember/object";
 import { on } from "@ember/modifier";
+import { action } from "@ember/object";
+import PlaceholdersList from "../placeholders-list";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class TextField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-text-list-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-text-list-field.gjs
@@ -1,8 +1,8 @@
-import BaseField from "./da-base-field";
-import MultiSelect from "select-kit/components/multi-select";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import { hash } from "@ember/helper";
+import MultiSelect from "select-kit/components/multi-select";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class TextListField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/fields/da-trust-levels-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-trust-levels-field.gjs
@@ -1,10 +1,12 @@
-import BaseField from "./da-base-field";
-import MultiSelect from "select-kit/components/multi-select";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
 import { inject as service } from "@ember/service";
+import MultiSelect from "select-kit/components/multi-select";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class TrustLevelsField extends BaseField {
+  @service site;
+
   <template>
     <section class="field category-field">
       <div class="control-group">
@@ -22,6 +24,4 @@ export default class TrustLevelsField extends BaseField {
       </div>
     </section>
   </template>
-
-  @service site;
 }

--- a/assets/javascripts/discourse/components/fields/da-user-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-user-field.gjs
@@ -1,9 +1,9 @@
-import { action } from "@ember/object";
-import BaseField from "./da-base-field";
 import { hash } from "@ember/helper";
-import DAFieldLabel from "./da-field-label";
-import DAFieldDescription from "./da-field-description";
+import { action } from "@ember/object";
 import UserChooser from "select-kit/components/user-chooser";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
 
 export default class UserField extends BaseField {
   <template>

--- a/assets/javascripts/discourse/components/placeholders-list.gjs
+++ b/assets/javascripts/discourse/components/placeholders-list.gjs
@@ -1,7 +1,7 @@
 import Component from "@glimmer/component";
+import { fn } from "@ember/helper";
 import { action } from "@ember/object";
 import DButton from "discourse/components/d-button";
-import { fn } from "@ember/helper";
 
 export default class PlaceholdersList extends Component {
   <template>

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-automation-new.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-automation-new.js
@@ -1,7 +1,7 @@
 import Controller from "@ember/controller";
 import EmberObject, { action } from "@ember/object";
-import { extractError } from "discourse/lib/ajax-error";
 import { inject as service } from "@ember/service";
+import { extractError } from "discourse/lib/ajax-error";
 
 export default class AutomationNew extends Controller {
   @service router;


### PR DESCRIPTION
It was complaining a lot here https://github.com/discourse/discourse-automation/actions/runs/7112464501/job/19362457179?pr=235

```
/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-boolean-field.gjs
Error:   1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-categories-field.gjs
Error:   1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-category-field.gjs
Error:   1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-category-notification-level-field.gjs
Error:   1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-choices-field.gjs
Error:   1:1   error  Run autofix to sort these imports!  simple-import-sort/imports
Error:   7:10  error  'action' is defined but never used  no-unused-vars

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-custom-field.gjs
Error:    1:1   error  Run autofix to sort these imports!                                            simple-import-sort/imports
Error:    2:10  error  'action' is defined but never used                                            no-unused-vars
Error:    9:10  error  'hash' is defined but never used                                              no-unused-vars
Error:   30:3   error  Expected property store to come before property __GLIMMER_TEMPLATE            sort-class-members/sort-class-members
Error:   31:3   error  Expected property allCustomFields to come before property __GLIMMER_TEMPLATE  sort-class-members/sort-class-members

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-date-time-field.gjs
Error:   1:1  error  Run autofix to sort these imports!  simple-import-sort/imports

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-email-group-user-field.gjs
Error:    1:1  error  Run autofix to sort these imports!                                       simple-import-sort/imports
Error:   34:3  error  Expected property recipients to come before property __GLIMMER_TEMPLATE  sort-class-members/sort-class-members
Error:   35:3  error  Expected property groups to come before property __GLIMMER_TEMPLATE      sort-class-members/sort-class-members

/home/runner/work/discourse-automation/discourse-automation/assets/javascripts/discourse/components/fields/da-group-field.gjs
Error:    1:1  error  Run autofix to sort these imports!                                      simple-import-sort/imports
Error:   31:3  error  Expected property allGroups to come before property __GLIMMER_TEMPLATE  sort-class-members/sort-class-members
```