### PR TITLE
FEATURE: support default values for scriptables

### DIFF
--- a/app/controllers/discourse_automation/admin_scriptables_controller.rb
+++ b/app/controllers/discourse_automation/admin_scriptables_controller.rb
@@ -16,6 +16,7 @@ module DiscourseAutomation
           }
         end
 
+      scriptables.sort_by! { |s| s[:name] }
       render_json_dump(scriptables: scriptables)
     end
   end

--- a/app/serializers/discourse_automation/template_serializer.rb
+++ b/app/serializers/discourse_automation/template_serializer.rb
@@ -2,10 +2,20 @@
 
 module DiscourseAutomation
   class TemplateSerializer < ApplicationSerializer
-    attributes :name, :component, :extra, :accepts_placeholders, :default_value, :is_required
+    attributes :name,
+               :component,
+               :extra,
+               :accepts_placeholders,
+               :read_only,
+               :default_value,
+               :is_required
 
     def default_value
-      scope[:automation].scriptable&.forced_triggerable&.dig(:state, name)
+      scope[:automation].scriptable&.forced_triggerable&.dig(:state, name) || object[:default_value]
+    end
+
+    def read_only
+      scope[:automation].scriptable&.forced_triggerable&.dig(:state, name).present?
     end
 
     def name

--- a/assets/javascripts/discourse/admin/models/discourse-automation-field.js
+++ b/assets/javascripts/discourse/admin/models/discourse-automation-field.js
@@ -16,7 +16,7 @@ export default class DiscourseAutomationField {
         template.default_value || template.value || json?.metadata?.value;
     } else {
       field.metadata.value =
-        json?.metadata?.value || template.default_value || template.value;
+        template.value || json?.metadata?.value || template.default_value;
     }
 
     field.isRequired = template.is_required;

--- a/assets/javascripts/discourse/admin/models/discourse-automation-field.js
+++ b/assets/javascripts/discourse/admin/models/discourse-automation-field.js
@@ -1,5 +1,4 @@
 import { tracked } from "@glimmer/tracking";
-import { isPresent } from "@ember/utils";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 
 export default class DiscourseAutomationField {
@@ -9,9 +8,17 @@ export default class DiscourseAutomationField {
     field.target = target;
     field.name = template.name;
     field.component = template.component;
-    field.metadata.value =
-      template.default_value || template.value || json?.metadata?.value;
-    field.isDisabled = isPresent(template.default_value);
+    field.isDisabled = template.read_only;
+
+    // backwards compatibility with forced scriptable fields
+    if (field.isDisabled) {
+      field.metadata.value =
+        template.default_value || template.value || json?.metadata?.value;
+    } else {
+      field.metadata.value =
+        json?.metadata?.value || template.default_value || template.value;
+    }
+
     field.isRequired = template.is_required;
     field.extra = new TrackedObject(template.extra);
     return field;

--- a/assets/stylesheets/common/discourse-automation.scss
+++ b/assets/stylesheets/common/discourse-automation.scss
@@ -71,7 +71,7 @@
     .control-label {
       margin: 0.25em 0.25em 0.25em 0;
       text-align: left;
-      width: 200px;
+      width: 180px;
       line-height: 27px;
     }
 

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -233,6 +233,11 @@ module DiscourseAutomation
       define_method("__scriptable_#{identifier}", &block)
     end
 
+    def self.remove(identifier)
+      @all_scriptables = nil
+      undef_method("__scriptable_#{identifier}")
+    end
+
     def self.all
       @all_scriptables ||=
         DiscourseAutomation::Scriptable.instance_methods(false).grep(/^__scriptable_/)

--- a/spec/system/smoke_test_spec.rb
+++ b/spec/system/smoke_test_spec.rb
@@ -2,12 +2,33 @@
 
 describe "DiscourseAutomation | smoke test", type: :system, js: true do
   fab!(:admin) { Fabricate(:admin) }
+  fab!(:group) { Fabricate(:group, name: "test") }
+  fab!(:badge) { Fabricate(:badge, name: "badge") }
 
   before do
-    Fabricate(:group, name: "test")
-    Fabricate(:badge, name: "badge")
     SiteSetting.discourse_automation_enabled = true
     sign_in(admin)
+  end
+
+  it "allows default_value on fields" do
+    DiscourseAutomation::Scriptable.add("test") do
+      triggerables %i[post_created_edited]
+      field :test, component: :text, default_value: "test-default-value"
+    end
+
+    visit("/admin/plugins/discourse-automation")
+    find(".new-automation").click
+    fill_in("automation-name", with: "aaaaa")
+    select_kit = PageObjects::Components::SelectKit.new(".scriptables")
+    select_kit.expand
+    select_kit.select_row_by_value("test")
+    find(".create-automation").click
+
+    select_kit = PageObjects::Components::SelectKit.new(".triggerables")
+    select_kit.expand
+    select_kit.select_row_by_value("post_created_edited")
+
+    expect(find(".field input[name=test]").value).to eq("test-default-value")
   end
 
   it "works" do

--- a/spec/system/smoke_test_spec.rb
+++ b/spec/system/smoke_test_spec.rb
@@ -10,25 +10,31 @@ describe "DiscourseAutomation | smoke test", type: :system, js: true do
     sign_in(admin)
   end
 
-  it "allows default_value on fields" do
-    DiscourseAutomation::Scriptable.add("test") do
-      triggerables %i[post_created_edited]
-      field :test, component: :text, default_value: "test-default-value"
+  context "when default_value fields are set" do
+    before do
+      DiscourseAutomation::Scriptable.add("test") do
+        triggerables %i[post_created_edited]
+        field :test, component: :text, default_value: "test-default-value"
+      end
     end
 
-    visit("/admin/plugins/discourse-automation")
-    find(".new-automation").click
-    fill_in("automation-name", with: "aaaaa")
-    select_kit = PageObjects::Components::SelectKit.new(".scriptables")
-    select_kit.expand
-    select_kit.select_row_by_value("test")
-    find(".create-automation").click
+    after { DiscourseAutomation::Scriptable.remove("test") }
 
-    select_kit = PageObjects::Components::SelectKit.new(".triggerables")
-    select_kit.expand
-    select_kit.select_row_by_value("post_created_edited")
+    it "populate correctly" do
+      visit("/admin/plugins/discourse-automation")
+      find(".new-automation").click
+      fill_in("automation-name", with: "aaaaa")
+      select_kit = PageObjects::Components::SelectKit.new(".scriptables")
+      select_kit.expand
+      select_kit.select_row_by_value("test")
+      find(".create-automation").click
 
-    expect(find(".field input[name=test]").value).to eq("test-default-value")
+      select_kit = PageObjects::Components::SelectKit.new(".triggerables")
+      select_kit.expand
+      select_kit.select_row_by_value("post_created_edited")
+
+      expect(find(".field input[name=test]").value).to eq("test-default-value")
+    end
   end
 
   it "works" do


### PR DESCRIPTION
In certain cases when creating an automation we may want to pre-populate
fields

This allows us to use `default_value: ...` to denote a default value for an
automation.

Also

- Fixes CSS on recurring automations, message was not aligned correctly
- Sort scriptables so we don't return them in random order
