### PR TITLE
FEATURE: new automation fields for post_created_edited and auto_tag_topic

### DIFF
--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -150,6 +150,9 @@ en:
             restricted_group:
               label: Group
               description: Optional, will trigger only if the post's topic is a private message in this group's inbox
+            restricted_tags:
+              label: Tags
+              description: Optional, will trigger only if the post's topic has any of these tags
             ignore_group_members:
               label: Ignore group members
               description: Skip the trigger if sender is a member of the Group specified above
@@ -162,6 +165,9 @@ en:
             first_topic_only:
               label: First topic only
               description: Will trigger only if the topic is the first topic a user created
+            first_post_in_topic:
+              label: First post in topic
+              description: Will trigger only if the post is the first post in the topic
           created: Created
           edited: Edited
         category_created_edited:
@@ -223,6 +229,9 @@ en:
             tags:
               label: Tags
               description: List of tags to add to the topic.
+            bump_topic:
+              label: Bump topic
+              description: Bump topic to the top of the latest list
         post:
           fields:
             creator:

--- a/lib/discourse_automation/scripts/auto_tag_topic.rb
+++ b/lib/discourse_automation/scripts/auto_tag_topic.rb
@@ -4,6 +4,7 @@ DiscourseAutomation::Scriptable::AUTO_TAG_TOPIC = "auto_tag_topic"
 
 DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_TAG_TOPIC) do
   field :tags, component: :tags, required: true
+  field :bump_topic, component: :boolean
 
   version 1
 
@@ -19,5 +20,8 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::AUTO_TAG_TO
     tags = fields.dig("tags", "value")
 
     DiscourseTagging.tag_topic_by_names(topic, Guardian.new(post.user), tags, append: true)
+
+    bump_topic = fields.dig("bump_topic", "value") || false
+    topic.update(bumped_at: Time.now) if bump_topic
   end
 end

--- a/lib/discourse_automation/triggers/post_created_edited.rb
+++ b/lib/discourse_automation/triggers/post_created_edited.rb
@@ -11,9 +11,11 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::POST_CREA
   field :action_type, component: :choices, extra: { content: ACTION_TYPE_CHOICES }
   field :restricted_category, component: :category
   field :restricted_group, component: :group
+  field :restricted_tags, component: :tags
   field :ignore_automated, component: :boolean
   field :ignore_group_members, component: :boolean
   field :valid_trust_levels, component: :"trust-levels"
   field :first_post_only, component: :boolean
   field :first_topic_only, component: :boolean
+  field :first_post_in_topic, component: :boolean
 end

--- a/spec/scripts/auto_tag_topic_spec.rb
+++ b/spec/scripts/auto_tag_topic_spec.rb
@@ -42,9 +42,7 @@ describe "AutoTagTopic" do
   end
 
   context "when bump_topic is true" do
-    before do
-      automation.upsert_field!("bump_topic", "boolean", { value: true })
-    end
+    before { automation.upsert_field!("bump_topic", "boolean", { value: true }) }
 
     it "bumps the topic" do
       post = create_post(topic: topic)
@@ -56,16 +54,14 @@ describe "AutoTagTopic" do
   end
 
   context "when bump_topic is false" do
-    before do
-      automation.upsert_field!("bump_topic", "boolean", { value: false })
-    end
+    before { automation.upsert_field!("bump_topic", "boolean", { value: false }) }
 
     it "doesn't bump the topic" do
       post = create_post(topic: topic)
       old_bumped_at = topic.reload.bumped_at
       automation.trigger!("post" => post)
 
-      expect(topic.reload.bumped_at).to eq(old_bumped_at)
+      expect(topic.reload.bumped_at).to eq_time(old_bumped_at)
     end
   end
 end

--- a/spec/scripts/auto_tag_topic_spec.rb
+++ b/spec/scripts/auto_tag_topic_spec.rb
@@ -40,4 +40,32 @@ describe "AutoTagTopic" do
       expect(topic.reload.tags.pluck(:name).sort).to match_array(%w[tag1 tag2 tag3])
     end
   end
+
+  context "when bump_topic is true" do
+    before do
+      automation.upsert_field!("bump_topic", "boolean", { value: true })
+    end
+
+    it "bumps the topic" do
+      post = create_post(topic: topic)
+      old_bumped_at = topic.reload.bumped_at
+      automation.trigger!("post" => post)
+
+      expect(topic.reload.bumped_at).not_to eq(old_bumped_at)
+    end
+  end
+
+  context "when bump_topic is false" do
+    before do
+      automation.upsert_field!("bump_topic", "boolean", { value: false })
+    end
+
+    it "doesn't bump the topic" do
+      post = create_post(topic: topic)
+      old_bumped_at = topic.reload.bumped_at
+      automation.trigger!("post" => post)
+
+      expect(topic.reload.bumped_at).to eq(old_bumped_at)
+    end
+  end
 end

--- a/spec/scripts/auto_tag_topic_spec.rb
+++ b/spec/scripts/auto_tag_topic_spec.rb
@@ -49,7 +49,7 @@ describe "AutoTagTopic" do
       old_bumped_at = topic.reload.bumped_at
       automation.trigger!("post" => post)
 
-      expect(topic.reload.bumped_at).not_to eq(old_bumped_at)
+      expect(topic.reload.bumped_at).not_to eq_time(old_bumped_at)
     end
   end
 


### PR DESCRIPTION
New automation fields:
* Post Created Edited trigger
  * restricted_tags
  * first_post_in_topic
* Auto Tag Topic script
  * bump_topic

![image](https://github.com/discourse/discourse-automation/assets/3530/401a451f-06fe-43be-b982-1a8b030176f8)
