### PR TITLE
FIX: Skip sending PMs to non-existent users

### DIFF
--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -222,10 +222,10 @@ module DiscourseAutomation
             return
           end
 
-          no_user = pm[:target_usernames].filter { |u| !User.find_by(username: u) }
-          if no_user.present?
-            Rails.logger.warn "[discourse-automation] Did not send PM #{pm[:title]} - target users do not exist: `#{no_user.join(",")}`"
-            pm[:target_usernames] = pm[:target_usernames] - no_user
+          existing_target_usernames = User.where(username: pm[:target_usernames]).pluck(:username)
+          if existing_target_usernames.length != pm[:target_usernames].length
+            Rails.logger.warn "[discourse-automation] Did not send PM #{pm[:title]} - target users do not exist: `#{(pm[:target_usernames] - existing_target_usernames).join(",")}`"
+            pm[:target_usernames] = existing_target_usernames
             return if pm[:target_usernames].empty?
           end
 

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -211,19 +211,32 @@ module DiscourseAutomation
           pm[:prefers_encrypt] = prefers_encrypt
           DiscourseAutomation::PendingPm.create!(pm)
         else
-          if sender = User.find_by(username: sender)
-            post_created = false
-            pm = pm.merge(archetype: Archetype.private_message)
-
-            if prefers_encrypt
-              pm[:target_usernames] = (pm[:target_usernames] || []).join(",")
-              post_created = EncryptedPostCreator.new(sender, pm).create
-            end
-
-            PostCreator.new(sender, pm).create! if !post_created
-          else
-            Rails.logger.warn "[discourse-automation] Couldn’t send PM to user with username: `#{sender}`."
+          sender = User.find_by(username: sender)
+          if !sender
+            Rails.logger.warn "[discourse-automation] Did not send PM #{pm[:title]} - sender does not exist: `#{sender}`"
+            return
           end
+
+          if (pm[:target_usernames] || []).empty?
+            Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames"
+            return
+          end
+
+          no_user = pm[:target_usernames].filter { |u| !User.find_by(username: u) }
+          if no_user.present?
+            Rails.logger.warn "[discourse-automation] Did not send PM #{pm[:title]} - target users do not exist: `#{no_user.join(",")}`"
+            pm[:target_usernames] = pm[:target_usernames] - no_user
+            return if pm[:target_usernames].empty?
+          end
+
+          post_created = false
+          pm = pm.merge(archetype: Archetype.private_message)
+          pm[:target_usernames] = (pm[:target_usernames] || []).join(",")
+          pm[:target_usernames]
+
+          post_created = EncryptedPostCreator.new(sender, pm).create if prefers_encrypt
+
+          PostCreator.new(sender, pm).create! if !post_created
         end
       end
     end

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -255,6 +255,34 @@ describe DiscourseAutomation::Scriptable do
           }.to raise_error(ActiveRecord::RecordNotSaved)
         end
       end
+
+      context "when pm target_usernames contain an invalid user" do
+        it "skips sending if there is only one target" do
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Tell me and I forget.",
+                raw: "0123456789" * 25 + "a",
+                target_usernames: ["non-existent-user"],
+              },
+            )
+          }.not_to change { Topic.count }
+        end
+
+        it "sends the pm without the invalid user" do
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Tell me and I forget.",
+                raw: "0123456789" * 25 + "a",
+                target_usernames: ["non-existent-user", user.username],
+              },
+            )
+          }.to change { Topic.count }
+
+          expect(Topic.last.allowed_users).to contain_exactly(Discourse.system_user, user)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### The fix

This fix checks for the PM's target_users existence, removes non-existent target users, then sends the PM depending on whether there are any valid target users. Warnings are also added to the rails logs.

This also allows the DiscourseAutomation::PendingPm to be successfully cleared.

### The context

Our automation job has an error that was surfaced:

```
Job exception: One of the users you are sending this message to could not be found.
```

This may happen if a user account is deleted after getting added to a group, and the automation sends the PM X minutes after the trigger. e.g. the screenshot below.

<img width="414" alt="Screenshot 2023-12-29 at 1 55 48 PM" src="https://github.com/discourse/discourse-automation/assets/1555215/b4601f3d-8692-4174-bfda-c933b1666980">