### PR TITLE
DEV: Handle auto-group refresh to fix tests

### DIFF
--- a/spec/scripts/auto_tag_topic_spec.rb
+++ b/spec/scripts/auto_tag_topic_spec.rb
@@ -7,7 +7,7 @@ describe "AutoTagTopic" do
   fab!(:tag1) { Fabricate(:tag, name: "tag1") }
   fab!(:tag2) { Fabricate(:tag, name: "tag2") }
   fab!(:tag3) { Fabricate(:tag, name: "tag3") }
-  fab!(:admin) { Fabricate(:admin) }
+  fab!(:admin) { Fabricate(:admin, refresh_auto_groups: true) }
 
   fab!(:automation) do
     Fabricate(:automation, script: DiscourseAutomation::Scriptable::AUTO_TAG_TOPIC)


### PR DESCRIPTION
### What is this change?

We've been moving TL based access to group based access in core. This requires auto-groups to be created in relevant tests for them to keep passing.