### PR TITLE
FIX: computes next daily recurring from now

### DIFF
--- a/lib/discourse_automation/triggers/recurring.rb
+++ b/lib/discourse_automation/triggers/recurring.rb
@@ -33,7 +33,7 @@ def setup_pending_automation(automation, fields)
     when "day"
       RRule::Rule
         .new("FREQ=DAILY;INTERVAL=#{interval}", dtstart: start_date)
-        .between(Time.now.end_of_day, interval_end.days.from_now)
+        .between(Time.now, interval_end.days.from_now)
         .first
     when "weekday"
       max_weekends = (interval_end.to_f / 5).ceil

--- a/spec/triggers/recurring_spec.rb
+++ b/spec/triggers/recurring_spec.rb
@@ -111,14 +111,22 @@ describe "Recurring" do
     end
 
     describe "every_day" do
-      before { upsert_period_field!(1, "day") }
+      before do
+        automation.upsert_field!(
+          "start_date",
+          "date_time",
+          { value: 1.minute.from_now },
+          target: "trigger",
+        )
+        upsert_period_field!(1, "day")
+      end
 
       it "creates the next iteration one day later" do
         automation.trigger!
 
         pending_automation = DiscourseAutomation::PendingAutomation.last
         start_date = Time.parse(automation.trigger_field("start_date")["value"])
-        expect(pending_automation.execute_at).to be_within_one_minute_of(start_date + 1.day)
+        expect(pending_automation.execute_at).to be_within_one_minute_of(start_date)
       end
     end
 


### PR DESCRIPTION
Prior to this fix, we would start to look for next daily event from the end of the current day. This could be problematic when you want to start scheduling an event later today.