### PR TITLE
FEATURE: Automated Post creation on user updated

### DIFF
--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -132,7 +132,7 @@ module DiscourseAutomation
       },
       "custom_fields" => {
         "value" => {
-          "type" =>  [{ type: "string" }],
+          "type" => [{ type: "string" }],
         },
       },
       "user" => {

--- a/app/models/discourse_automation/field.rb
+++ b/app/models/discourse_automation/field.rb
@@ -130,9 +130,20 @@ module DiscourseAutomation
           "type" => "integer",
         },
       },
+      "custom_fields" => {
+        "value" => {
+          "type" =>  [{ type: "string" }],
+        },
+      },
       "user" => {
         "value" => {
           "type" => "string",
+        },
+      },
+      "user_profile" => {
+        "value" => {
+          "type" => "array",
+          "items" => [{ type: "string" }],
         },
       },
       "users" => {

--- a/assets/javascripts/discourse/components/automation-field.gjs
+++ b/assets/javascripts/discourse/components/automation-field.gjs
@@ -20,6 +20,8 @@ import DaTextListField from "./fields/da-text-list-field";
 import DaTrustLevelsField from "./fields/da-trust-levels-field";
 import DaUserField from "./fields/da-user-field";
 import DaUsersField from "./fields/da-users-field";
+import DaUserProfileField from "./fields/da-user-profile-field";
+import DaCustomFields from "./fields/da-custom-fields";
 
 const FIELD_COMPONENTS = {
   period: DaPeriodField,
@@ -31,6 +33,7 @@ const FIELD_COMPONENTS = {
   categories: DaCategoriesField,
   user: DaUserField,
   users: DaUsersField,
+  user_profile: DaUserProfileField,
   post: DaPostField,
   tags: DaTagsField,
   "key-value": DaKeyValueField,
@@ -42,6 +45,7 @@ const FIELD_COMPONENTS = {
   category_notification_level: DaCategoryNotificationlevelField,
   email_group_user: DaEmailGroupUserField,
   custom_field: DaCustomField,
+  custom_fields: DaCustomFields,
 };
 
 export default class AutomationField extends Component {

--- a/assets/javascripts/discourse/components/automation-field.gjs
+++ b/assets/javascripts/discourse/components/automation-field.gjs
@@ -6,6 +6,7 @@ import DaCategoryField from "./fields/da-category-field";
 import DaCategoryNotificationlevelField from "./fields/da-category-notification-level-field";
 import DaChoicesField from "./fields/da-choices-field";
 import DaCustomField from "./fields/da-custom-field";
+import DaCustomFields from "./fields/da-custom-fields";
 import DaDateTimeField from "./fields/da-date-time-field";
 import DaEmailGroupUserField from "./fields/da-email-group-user-field";
 import DaGroupField from "./fields/da-group-field";
@@ -19,9 +20,8 @@ import DaTextField from "./fields/da-text-field";
 import DaTextListField from "./fields/da-text-list-field";
 import DaTrustLevelsField from "./fields/da-trust-levels-field";
 import DaUserField from "./fields/da-user-field";
-import DaUsersField from "./fields/da-users-field";
 import DaUserProfileField from "./fields/da-user-profile-field";
-import DaCustomFields from "./fields/da-custom-fields";
+import DaUsersField from "./fields/da-users-field";
 
 const FIELD_COMPONENTS = {
   period: DaPeriodField,

--- a/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
+++ b/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
@@ -1,13 +1,12 @@
 import { tracked } from "@glimmer/tracking";
+import { hash } from "@ember/helper";
 import didInsert from "@ember/render-modifiers/modifiers/did-insert";
 import { inject as service } from "@ember/service";
 import { bind } from "discourse-common/utils/decorators";
-import ComboBox from "select-kit/components/combo-box";
+import MultiSelect from "select-kit/components/multi-select";
 import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
 import DAFieldLabel from "./da-field-label";
-import MultiSelect from "select-kit/components/multi-select";
-import { hash } from "@ember/helper";
 
 export default class GroupField extends BaseField {
   @service store;

--- a/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
+++ b/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
@@ -1,0 +1,42 @@
+import { tracked } from "@glimmer/tracking";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { inject as service } from "@ember/service";
+import { bind } from "discourse-common/utils/decorators";
+import ComboBox from "select-kit/components/combo-box";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
+import MultiSelect from "select-kit/components/multi-select";
+import { hash } from "@ember/helper";
+
+export default class GroupField extends BaseField {
+  @service store;
+  @tracked allCustomFields = [];
+
+  <template>
+    <section class="field group-field" {{didInsert this.loadUserFields}}>
+      <div class="control-group">
+        <DAFieldLabel @label={{@label}} @field={{@field}} />
+
+        <div class="controls">
+          <MultiSelect
+            @value={{@field.metadata.value}}
+            @content={{this.allCustomFields}}
+            @onChange={{this.mutValue}}
+            @nameProperty={{null}}
+            @valueProperty={{null}}
+            @options={{hash allowAny=true disabled=@field.isDisabled}}
+          />
+          <DAFieldDescription @description={{@description}} />
+        </div>
+      </div>
+    </section>
+  </template>
+
+  @bind
+  loadUserFields() {
+    this.store.findAll("user-field").then((fields) => {
+      this.allCustomFields = fields.content.map((field) => field.name);
+    });
+  }
+}

--- a/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
@@ -1,13 +1,10 @@
 import { tracked } from "@glimmer/tracking";
-import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { hash } from "@ember/helper";
 import { inject as service } from "@ember/service";
-import { bind } from "discourse-common/utils/decorators";
-import ComboBox from "select-kit/components/combo-box";
+import MultiSelect from "select-kit/components/multi-select";
 import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
 import DAFieldLabel from "./da-field-label";
-import MultiSelect from "select-kit/components/multi-select";
-import { hash } from "@ember/helper";
 
 export default class GroupField extends BaseField {
   @service store;

--- a/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
@@ -1,0 +1,44 @@
+import { tracked } from "@glimmer/tracking";
+import didInsert from "@ember/render-modifiers/modifiers/did-insert";
+import { inject as service } from "@ember/service";
+import { bind } from "discourse-common/utils/decorators";
+import ComboBox from "select-kit/components/combo-box";
+import BaseField from "./da-base-field";
+import DAFieldDescription from "./da-field-description";
+import DAFieldLabel from "./da-field-label";
+import MultiSelect from "select-kit/components/multi-select";
+import { hash } from "@ember/helper";
+
+export default class GroupField extends BaseField {
+  @service store;
+  @service currentUser;
+  @tracked allProfileFields = [];
+
+  userProfileFields = [
+    "bio_raw",
+    "website",
+    "location",
+    "date_of_birth",
+    "timezone",
+  ];
+  <template>
+    <section class="field group-field">
+      <div class="control-group">
+        <DAFieldLabel @label={{@label}} @field={{@field}} />
+        <div class="controls">
+
+          <MultiSelect
+            @value={{@field.metadata.value}}
+            @content={{this.userProfileFields}}
+            @onChange={{this.mutValue}}
+            @nameProperty={{null}}
+            @valueProperty={{null}}
+            @options={{hash allowAny=true disabled=@field.isDisabled}}
+          />
+
+          <DAFieldDescription @description={{@description}} />
+        </div>
+      </div>
+    </section>
+  </template>
+}

--- a/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-user-profile-field.gjs
@@ -1,14 +1,11 @@
 import { tracked } from "@glimmer/tracking";
 import { hash } from "@ember/helper";
-import { inject as service } from "@ember/service";
 import MultiSelect from "select-kit/components/multi-select";
 import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
 import DAFieldLabel from "./da-field-label";
 
-export default class GroupField extends BaseField {
-  @service store;
-  @service currentUser;
+export default class UserProfileField extends BaseField {
   @tracked allProfileFields = [];
 
   userProfileFields = [
@@ -18,12 +15,12 @@ export default class GroupField extends BaseField {
     "date_of_birth",
     "timezone",
   ];
+
   <template>
     <section class="field group-field">
       <div class="control-group">
         <DAFieldLabel @label={{@label}} @field={{@field}} />
         <div class="controls">
-
           <MultiSelect
             @value={{@field.metadata.value}}
             @content={{this.userProfileFields}}

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -164,6 +164,20 @@ en:
               description: Will trigger only if the topic is the first topic a user created
           created: Created
           edited: Edited
+        user_updated:
+          fields:
+            user_profile: 
+              label: User profile fields
+              description:  Will trigger only if the user has filled this profile data
+            custom_fields: 
+              label: User custom fields
+              description: Will trigger only if the user has filled this custom fields
+            first_post_only:
+              label: First post only
+              description: Will trigger only if the post is the first post a user created
+            automation_name:
+              label: Name of the user automation
+              description: Allows to have different user automations
         category_created_edited:
           fields:
             restricted_category:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -168,16 +168,16 @@ en:
           fields:
             user_profile: 
               label: User profile fields
-              description:  Will trigger only if the user has filled this profile data
+              description: Will trigger only if the user has filled this profile data
             custom_fields: 
               label: User custom fields
-              description: Will trigger only if the user has filled this custom fields
+              description: Will trigger only if the user has filled this custom field
             first_post_only:
               label: First post only
-              description: Will trigger only if the post is the first post a user created
+              description: Will trigger only if this post is the first post a user created
             automation_name:
-              label: Name of the user automation
-              description: Allows to have different user automations
+              label: Name of the automation trigger
+              description: Allows to have different user automations. Using the same name might cause issues.
         category_created_edited:
           fields:
             restricted_category:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -55,7 +55,7 @@ en:
         title: After post cook
         description: When a post content is cooked the automation will be triggered
       user_updated:
-        title: User Update
+        title: After user update
         description: When a user updates any information the automation will be triggered
     scriptables:
       post:

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -54,6 +54,9 @@ en:
       after_post_cook:
         title: After post cook
         description: When a post content is cooked the automation will be triggered
+      user_updated:
+        title: User Update
+        description: When a user updates any information the automation will be triggered
     scriptables:
       post:
         title: Create a post

--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -65,6 +65,59 @@ module DiscourseAutomation
         end
     end
 
+    def self.handle_user_updated(user)
+      return if user.id < 0
+
+      name = DiscourseAutomation::Triggerable::USER_UPDATED
+
+      DiscourseAutomation::Automation
+        .where(trigger: name, enabled: true)
+        .find_each do |automation|
+          if automation.trigger_field("first_post_only")["value"] &&
+               UserCustomField.find_by(name: automation.trigger_field("automation_name")["value"])
+            next
+          end
+
+          required_custom_fields = automation.trigger_field("custom_fields")
+          user_data = {}
+          user_custom_fields_names = UserField.all.map(&:name)
+          user_custom_fields_data = DB.query <<-SQL
+            SELECT uf.name AS field_name, ucf.value AS field_value
+            FROM user_fields uf
+            JOIN user_custom_fields ucf ON CONCAT('user_field_', uf.id) = ucf.name
+            WHERE ucf.user_id = #{user.id};
+          SQL
+
+          user_custom_fields_data =
+            user_custom_fields_data.each_with_object({}) do |obj, hash|
+              field_name = obj.field_name
+              field_value = obj.field_value
+              hash[field_name] = field_value
+            end
+
+          if required_custom_fields["value"]
+            if required_custom_fields["value"].any? { |field|
+                 user_custom_fields_data[field].blank?
+               }
+              next
+            end
+            user_data[:custom_fields] = user_custom_fields_data
+          end
+          required_user_profile_fields = automation.trigger_field("user_profile")
+          user_profile_data = UserProfile.find(user.id).attributes
+          if required_user_profile_fields["value"]
+            if required_user_profile_fields["value"].any? { |field|
+                 user_profile_data[field].blank?
+               }
+              next
+            end
+            user_data[:profile_data] = user_profile_data
+          end
+
+          automation.trigger!("kind" => name, "user" => user, "user_data" => user_data)
+        end
+    end
+
     def self.handle_category_created_edited(category, action)
       name = DiscourseAutomation::Triggerable::CATEGORY_CREATED_EDITED
 

--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -73,10 +73,9 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
-          has_created_post = UserCustomField.find_by(name: automation.trigger_field("automation_name")["value"])
-          if automation.trigger_field("first_post_only")["value"] && has_created_post
-            next
-          end
+          has_created_post =
+            UserCustomField.find_by(name: automation.trigger_field("automation_name")["value"])
+          next if automation.trigger_field("first_post_only")["value"] && has_created_post
 
           required_custom_fields = automation.trigger_field("custom_fields")
           user_data = {}

--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -73,8 +73,8 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
-          if automation.trigger_field("first_post_only")["value"] &&
-               UserCustomField.find_by(name: automation.trigger_field("automation_name")["value"])
+          has_created_post = UserCustomField.find_by(name: automation.trigger_field("automation_name")["value"])
+          if automation.trigger_field("first_post_only")["value"] && has_created_post
             next
           end
 

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -11,7 +11,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
   field :topic, component: :text, required: true
   field :post, component: :post, required: true
 
-  triggerables %i[recurring point_in_time]
+  triggerables %i[recurring point_in_time user_updated]
 
   script do |context, fields, automation|
     creator_username = fields.dig("creator", "value") || Discourse.system_user.username
@@ -19,10 +19,29 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     post_raw = fields.dig("post", "value")
 
     placeholders = { creator_username: creator_username }.merge(context["placeholders"] || {})
-
     creator = User.find_by(username: creator_username)
     topic = Topic.find_by(id: topic_id)
 
-    PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator && topic
+    if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED
+      user_data = context["user_data"]
+      user_profile_data = user_data[:profile_data]
+      user_custom_fields =
+        user_data[:custom_fields].each_with_object({}) do |(k, v), hash|
+          hash[k.gsub(/\s+/, "_").underscore] = v
+        end
+      user = User.find(context["user"].id)
+      placeholders = placeholders.merge(user_profile_data, user_custom_fields)
+
+      post_raw = utils.apply_placeholders(post_raw, placeholders)
+    end
+
+    new_post = PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator &&
+      topic
+    if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED && new_post.persisted?
+      user.user_custom_fields.create(
+        name: automation.trigger_field("automation_name")["value"],
+        value: "true",
+      )
+    end
   end
 end

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+DiscourseAutomation::Triggerable::USER_UPDATED = "user_updated"
+
+DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
+  field :automation_name, component: :text, required: true
+  field :custom_fields, component: :custom_fields, required: true
+  field :user_profile, component: :user_profile, required: true
+  field :first_post_only, component: :boolean
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -71,6 +71,7 @@ after_initialize do
     lib/discourse_automation/triggers/user_promoted
     lib/discourse_automation/triggers/user_removed_from_group
     lib/discourse_automation/triggers/user_first_logged_in
+    lib/discourse_automation/triggers/user_updated
   ].each { |path| require_relative path }
 
   reloadable_patch { Post.prepend DiscourseAutomation::PostExtension }
@@ -197,6 +198,11 @@ after_initialize do
     DiscourseAutomation::Scriptable::AUTO_RESPONDER_TRIGGERED_IDS,
     [:integer],
   )
+
+  on(:user_updated) do |user|
+    DiscourseAutomation::EventHandlers.handle_user_updated(user)
+  end
+
   register_user_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])
   register_post_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])
   register_post_custom_field_type("stalled_wiki_triggered_at", :string)

--- a/plugin.rb
+++ b/plugin.rb
@@ -199,9 +199,7 @@ after_initialize do
     [:integer],
   )
 
-  on(:user_updated) do |user|
-    DiscourseAutomation::EventHandlers.handle_user_updated(user)
-  end
+  on(:user_updated) { |user| DiscourseAutomation::EventHandlers.handle_user_updated(user) }
 
   register_user_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])
   register_post_custom_field_type(DiscourseAutomation::CUSTOM_FIELD, [:integer])

--- a/spec/scripts/post_spec.rb
+++ b/spec/scripts/post_spec.rb
@@ -17,8 +17,6 @@ describe "Post" do
       )
     end
 
-    
-
     before do
       automation.upsert_field!(
         "execute_at",
@@ -75,10 +73,10 @@ describe "Post" do
   end
 
   context "when using user_updated trigger" do
-    fab!(:user_field_1){Fabricate(:user_field, name: "custom field 1")}
-    fab!(:user_field_2){Fabricate(:user_field, name: "custom field 2")}
+    fab!(:user_field_1) { Fabricate(:user_field, name: "custom field 1") }
+    fab!(:user_field_2) { Fabricate(:user_field, name: "custom field 2") }
 
-    fab!(:user) do 
+    fab!(:user) do
       user = Fabricate(:user, trust_level: TrustLevel[0])
       user.set_user_field(user_field_1.id, "Answer custom 1")
       user.set_user_field(user_field_2.id, "Answer custom 2")
@@ -89,31 +87,39 @@ describe "Post" do
     end
 
     fab!(:automation) do
-      automation = Fabricate(:automation, script: DiscourseAutomation::Scriptable::POST, trigger: DiscourseAutomation::Triggerable::USER_UPDATED)
+      automation =
+        Fabricate(
+          :automation,
+          script: DiscourseAutomation::Scriptable::POST,
+          trigger: DiscourseAutomation::Triggerable::USER_UPDATED,
+        )
       automation.upsert_field!(
-              "automation_name",
-              "text",
-              { value: "Automation Test" }, target: "trigger"
-              )
-      automation.upsert_field!(
-      "custom_fields",
-      "custom_fields",
-      { value: ["custom field 1", "custom field 2"] }, target: "trigger"
+        "automation_name",
+        "text",
+        { value: "Automation Test" },
+        target: "trigger",
       )
       automation.upsert_field!(
-      "user_profile",
-      "user_profile",
-      { value: ["location"] }, target: "trigger"
+        "custom_fields",
+        "custom_fields",
+        { value: ["custom field 1", "custom field 2"] },
+        target: "trigger",
       )
       automation.upsert_field!(
-      "first_post_only",
-      "boolean",
-      { value: true }, target: "trigger"
+        "user_profile",
+        "user_profile",
+        { value: ["location"] },
+        target: "trigger",
       )
+      automation.upsert_field!("first_post_only", "boolean", { value: true }, target: "trigger")
       automation
     end
-    let!(:user_raw_post){"This is a raw test post for user custom field 1: %%CUSTOM_FIELD_1%%, custom field 2: %%CUSTOM_FIELD_2%% and location: %%LOCATION%%"}
-    let!(:placeholder_applied_user_raw_post){"This is a raw test post for user custom field 1: #{user.custom_fields["user_field_#{user_field_1.id}"]}, custom field 2: #{user.custom_fields["user_field_#{user_field_2.id}"]} and location: #{user.user_profile.location}"}
+    let!(:user_raw_post) do
+      "This is a raw test post for user custom field 1: %%CUSTOM_FIELD_1%%, custom field 2: %%CUSTOM_FIELD_2%% and location: %%LOCATION%%"
+    end
+    let!(:placeholder_applied_user_raw_post) do
+      "This is a raw test post for user custom field 1: #{user.custom_fields["user_field_#{user_field_1.id}"]}, custom field 2: #{user.custom_fields["user_field_#{user_field_2.id}"]} and location: #{user.user_profile.location}"
+    end
 
     before do
       automation.upsert_field!("topic", "text", { value: topic_1.id }, target: "script")
@@ -122,10 +128,9 @@ describe "Post" do
 
     it "Creates a post correctly" do
       expect {
-        UserUpdater.new(user,user).update(location: "Japan")
+        UserUpdater.new(user, user).update(location: "Japan")
         expect(topic_1.posts.last.raw).to eq(placeholder_applied_user_raw_post)
       }.to change { topic_1.posts.count }.by(1)
-      
     end
   end
 end

--- a/spec/scripts/post_spec.rb
+++ b/spec/scripts/post_spec.rb
@@ -17,6 +17,8 @@ describe "Post" do
       )
     end
 
+    
+
     before do
       automation.upsert_field!(
         "execute_at",
@@ -69,6 +71,61 @@ describe "Post" do
 
         expect(topic_1.posts.last.raw).to eq(raw)
       }.to change { topic_1.posts.count }.by(1)
+    end
+  end
+
+  context "when using user_updated trigger" do
+    fab!(:user_field_1){Fabricate(:user_field, name: "custom field 1")}
+    fab!(:user_field_2){Fabricate(:user_field, name: "custom field 2")}
+
+    fab!(:user) do 
+      user = Fabricate(:user, trust_level: TrustLevel[0])
+      user.set_user_field(user_field_1.id, "Answer custom 1")
+      user.set_user_field(user_field_2.id, "Answer custom 2")
+      user.user_profile.location = "Japan"
+      user.user_profile.save
+      user.save
+      user
+    end
+
+    fab!(:automation) do
+      automation = Fabricate(:automation, script: DiscourseAutomation::Scriptable::POST, trigger: DiscourseAutomation::Triggerable::USER_UPDATED)
+      automation.upsert_field!(
+              "automation_name",
+              "text",
+              { value: "Automation Test" }, target: "trigger"
+              )
+      automation.upsert_field!(
+      "custom_fields",
+      "custom_fields",
+      { value: ["custom field 1", "custom field 2"] }, target: "trigger"
+      )
+      automation.upsert_field!(
+      "user_profile",
+      "user_profile",
+      { value: ["location"] }, target: "trigger"
+      )
+      automation.upsert_field!(
+      "first_post_only",
+      "boolean",
+      { value: true }, target: "trigger"
+      )
+      automation
+    end
+    let!(:user_raw_post){"This is a raw test post for user custom field 1: %%CUSTOM_FIELD_1%%, custom field 2: %%CUSTOM_FIELD_2%% and location: %%LOCATION%%"}
+    let!(:placeholder_applied_user_raw_post){"This is a raw test post for user custom field 1: #{user.custom_fields["user_field_#{user_field_1.id}"]}, custom field 2: #{user.custom_fields["user_field_#{user_field_2.id}"]} and location: #{user.user_profile.location}"}
+
+    before do
+      automation.upsert_field!("topic", "text", { value: topic_1.id }, target: "script")
+      automation.upsert_field!("post", "post", { value: user_raw_post }, target: "script")
+    end
+
+    it "Creates a post correctly" do
+      expect {
+        UserUpdater.new(user,user).update(location: "Japan")
+        expect(topic_1.posts.last.raw).to eq(placeholder_applied_user_raw_post)
+      }.to change { topic_1.posts.count }.by(1)
+      
     end
   end
 end

--- a/spec/triggers/user_updated_spec.rb
+++ b/spec/triggers/user_updated_spec.rb
@@ -4,10 +4,10 @@ require_relative "../discourse_automation_helper"
 
 describe "UserUpdated" do
   before { SiteSetting.discourse_automation_enabled = true }
-  fab!(:user_field_1){Fabricate(:user_field, name: "custom field 1")}
-  fab!(:user_field_2){Fabricate(:user_field, name: "custom field 2")}
+  fab!(:user_field_1) { Fabricate(:user_field, name: "custom field 1") }
+  fab!(:user_field_2) { Fabricate(:user_field, name: "custom field 2") }
 
-  fab!(:user) do 
+  fab!(:user) do
     user = Fabricate(:user, trust_level: TrustLevel[0])
     user.set_user_field(user_field_1.id, "Answer custom 1")
     user.set_user_field(user_field_2.id, "Answer custom 2")
@@ -18,36 +18,37 @@ describe "UserUpdated" do
   fab!(:automation) do
     automation = Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::USER_UPDATED)
     automation.upsert_field!(
-            "automation_name",
-            "text",
-            { value: "Automation Test" }, target: "trigger"
-            )
-    automation.upsert_field!(
-    "custom_fields",
-    "custom_fields",
-    { value: ["custom field 1", "custom field 2"] }, target: "trigger"
+      "automation_name",
+      "text",
+      { value: "Automation Test" },
+      target: "trigger",
     )
     automation.upsert_field!(
-    "user_profile",
-    "user_profile",
-    { value: ["location"] }, target: "trigger"
+      "custom_fields",
+      "custom_fields",
+      { value: ["custom field 1", "custom field 2"] },
+      target: "trigger",
     )
     automation.upsert_field!(
-    "first_post_only",
-    "boolean",
-    { value: true }, target: "trigger"
+      "user_profile",
+      "user_profile",
+      { value: ["location"] },
+      target: "trigger",
     )
+    automation.upsert_field!("first_post_only", "boolean", { value: true }, target: "trigger")
     automation
   end
 
   it "has the correct data" do
-    script_input = capture_contexts { UserUpdater.new(user,user).update(location: "Japan") }
+    script_input = capture_contexts { UserUpdater.new(user, user).update(location: "Japan") }
     script_input = script_input.first
-    
+
     expect(script_input["kind"]).to eq(DiscourseAutomation::Triggerable::USER_UPDATED)
     expect(script_input["user"]).to eq(user)
     expect(script_input["user_data"].count).to eq(2)
-    expect(script_input["user_data"][:custom_fields][user_field_1.name]).to eq(user.custom_fields["user_field_#{user_field_1.id}"])
+    expect(script_input["user_data"][:custom_fields][user_field_1.name]).to eq(
+      user.custom_fields["user_field_#{user_field_1.id}"],
+    )
     expect(script_input["user_data"][:profile_data]["location"]).to eq("Japan")
   end
 end

--- a/spec/triggers/user_updated_spec.rb
+++ b/spec/triggers/user_updated_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require_relative "../discourse_automation_helper"
+
+describe "UserUpdated" do
+  before { SiteSetting.discourse_automation_enabled = true }
+  fab!(:user_field_1){Fabricate(:user_field, name: "custom field 1")}
+  fab!(:user_field_2){Fabricate(:user_field, name: "custom field 2")}
+
+  fab!(:user) do 
+    user = Fabricate(:user, trust_level: TrustLevel[0])
+    user.set_user_field(user_field_1.id, "Answer custom 1")
+    user.set_user_field(user_field_2.id, "Answer custom 2")
+    user.save
+    user
+  end
+
+  fab!(:automation) do
+    automation = Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::USER_UPDATED)
+    automation.upsert_field!(
+            "automation_name",
+            "text",
+            { value: "Automation Test" }, target: "trigger"
+            )
+    automation.upsert_field!(
+    "custom_fields",
+    "custom_fields",
+    { value: ["custom field 1", "custom field 2"] }, target: "trigger"
+    )
+    automation.upsert_field!(
+    "user_profile",
+    "user_profile",
+    { value: ["location"] }, target: "trigger"
+    )
+    automation.upsert_field!(
+    "first_post_only",
+    "boolean",
+    { value: true }, target: "trigger"
+    )
+    automation
+  end
+
+  it "has the correct data" do
+    script_input = capture_contexts { UserUpdater.new(user,user).update(location: "Japan") }
+    script_input = script_input.first
+    
+    expect(script_input["kind"]).to eq(DiscourseAutomation::Triggerable::USER_UPDATED)
+    expect(script_input["user"]).to eq(user)
+    expect(script_input["user_data"].count).to eq(2)
+    expect(script_input["user_data"][:custom_fields][user_field_1.name]).to eq(user.custom_fields["user_field_#{user_field_1.id}"])
+    expect(script_input["user_data"][:profile_data]["location"]).to eq("Japan")
+  end
+end


### PR DESCRIPTION
**Context**
Customer wants to be able to create posts when a user joins their community.

**Problem**
The current implementation of the Automation plugin doesn't support the creation of Posts after user creation or update.

**Solution**
Implement a workflow to allow the Automation plugin `Post` script to work with the `user_updated` event by creating a corresponding trigger and event handler.  Implement logic to make sure the script doesn't run if the user hasn't filled in the required information and/or, if there should only be a post of this type, there is no duplication of this post.