### PR TITLE
FEATURE: allow either custom_fields or user_fields in trigger

### DIFF
--- a/app/models/discourse_automation/automation.rb
+++ b/app/models/discourse_automation/automation.rb
@@ -18,6 +18,7 @@ module DiscourseAutomation
              foreign_key: "automation_id"
 
     validates :script, presence: true
+    validate :validate_trigger_fields
 
     attr_accessor :running_in_background
 
@@ -69,6 +70,10 @@ module DiscourseAutomation
     def trigger_field(name)
       field = fields.find_by(target: "trigger", name: name)
       field ? field.metadata : {}
+    end
+
+    def has_trigger_field?(name)
+      !!fields.find_by(target: "trigger", name: name)
     end
 
     def script_field(name)
@@ -159,6 +164,12 @@ module DiscourseAutomation
       pending_automations.delete_all
       pending_pms.delete_all
       scriptable&.on_reset&.call(self)
+    end
+
+    private
+
+    def validate_trigger_fields
+      !triggerable || triggerable.valid?(self)
     end
   end
 end

--- a/assets/javascripts/discourse/components/fields/da-period-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-period-field.gjs
@@ -17,15 +17,8 @@ export default class PeriodField extends BaseField {
   constructor() {
     super(...arguments);
 
-    if (!this.args.field.metadata.value) {
-      this.args.field.metadata.value = new TrackedObject({
-        interval: 1,
-        frequency: null,
-      });
-    }
-
-    this.interval = this.args.field.metadata.value.interval;
-    this.frequency = this.args.field.metadata.value.frequency;
+    this.interval = this.args.field.metadata.value?.interval || 1;
+    this.frequency = this.args.field.metadata.value?.frequency;
   }
 
   get recurringLabel() {
@@ -41,13 +34,24 @@ export default class PeriodField extends BaseField {
     });
   }
 
+  ensureValue() {
+    if (!this.args.field.metadata.value) {
+      this.args.field.metadata.value = new TrackedObject({
+        interval: this.interval,
+        frequency: this.frequency,
+      });
+    }
+  }
+
   @action
   mutInterval(event) {
+    this.ensureValue();
     this.args.field.metadata.value.interval = event.target.value;
   }
 
   @action
   mutFrequency(value) {
+    this.ensureValue();
     this.args.field.metadata.value.frequency = value;
     this.frequency = value;
   }

--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -8,6 +8,8 @@ en:
         invalid_field: Field’s component `%{component}` is not usable on `%{target}:%{target_name}.`
         invalid_metadata: Data for `%{field}` is invalid or component `%{component}` is unknown.
     triggerables:
+      errors:
+        custom_fields_or_user_profile_required: "At least one of 'custom_fields' or 'user_profile' must be provided."
       user_badge_granted:
         title: User badge granted
         doc: Triggers an automation when a user is granted a badge.

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -23,6 +23,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     topic = Topic.find_by(id: topic_id)
 
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED
+      user = context["user"]
       user_data = context["user_data"]
       user_profile_data = user_data[:profile_data]
       user_custom_fields = {}
@@ -30,6 +31,8 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
         user_custom_fields[k.gsub(/\s+/, "_").underscore] = v
       end
       user = User.find(context["user"].id)
+      placeholders["username"] = user.username
+      placeholders["name"] = user.name
       placeholders = placeholders.merge(user_profile_data, user_custom_fields)
 
       post_raw = utils.apply_placeholders(post_raw, placeholders)

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -25,10 +25,10 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED
       user_data = context["user_data"]
       user_profile_data = user_data[:profile_data]
-      user_custom_fields =
-        user_data[:custom_fields].each_with_object({}) do |(k, v), hash|
-          hash[k.gsub(/\s+/, "_").underscore] = v
-        end
+      user_custom_fields = {}
+      user_data[:custom_fields]&.each do |k, v|
+        user_custom_fields[k.gsub(/\s+/, "_").underscore] = v
+      end
       user = User.find(context["user"].id)
       placeholders = placeholders.merge(user_profile_data, user_custom_fields)
 

--- a/lib/discourse_automation/triggerable.rb
+++ b/lib/discourse_automation/triggerable.rb
@@ -14,6 +14,7 @@ module DiscourseAutomation
       @on_update_block = proc {}
       @on_call_block = proc {}
       @not_found = false
+      @validations = []
 
       eval! if @name
     end
@@ -28,6 +29,16 @@ module DiscourseAutomation
 
     def triggerable?
       true
+    end
+
+    def validate(&block)
+      @validations << block
+    end
+
+    def valid?(automation)
+      @validations.each { |block| automation.instance_exec(&block) }
+
+      automation.errors.blank?
     end
 
     def placeholders

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -1,10 +1,28 @@
 # frozen_string_literal: true
 
-DiscourseAutomation::Triggerable::USER_UPDATED = "user_updated"
+class DiscourseAutomation::Triggerable
+  USER_UPDATED = "user_updated"
+end
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
   field :automation_name, component: :text, required: true
-  field :custom_fields, component: :custom_fields, required: true
-  field :user_profile, component: :user_profile, required: true
+  field :custom_fields, component: :custom_fields
+  field :user_profile, component: :user_profile
   field :first_post_only, component: :boolean
+
+  validate do
+    has_triggers = has_trigger_field?(:custom_fields) && has_trigger_field?(:user_profile)
+    custom_fields = trigger_field(:custom_fields)["value"]
+    user_profile = trigger_field(:user_profile)["value"]
+
+    if has_triggers && custom_fields.blank? && user_profile.blank?
+      errors.add(
+        :base,
+        I18n.t("discourse_automation.triggerables.errors.custom_fields_or_user_profile_required"),
+      )
+      false
+    else
+      true
+    end
+  end
 end

--- a/spec/triggers/user_updated_spec.rb
+++ b/spec/triggers/user_updated_spec.rb
@@ -39,6 +39,32 @@ describe "UserUpdated" do
     automation
   end
 
+  context "when custom_fields and user_profile are blank" do
+    let(:automation) do
+      Fabricate(
+        :automation,
+        trigger: DiscourseAutomation::Triggerable::USER_UPDATED,
+      ).tap do |automation|
+        automation.upsert_field!(
+          "automation_name",
+          "text",
+          { value: "Test Automation" },
+          target: "trigger",
+        )
+        automation.upsert_field!("custom_fields", "custom_fields", { value: [] }, target: "trigger")
+        automation.upsert_field!("user_profile", "user_profile", { value: [] }, target: "trigger")
+      end
+    end
+
+    it "adds an error to the automation" do
+      expect(automation.save).to eq(false)
+      errors = automation.errors.full_messages
+      expect(errors).to include(
+        I18n.t("discourse_automation.triggerables.errors.custom_fields_or_user_profile_required"),
+      )
+    end
+  end
+
   it "has the correct data" do
     script_input = capture_contexts { UserUpdater.new(user, user).update(location: "Japan") }
     script_input = script_input.first


### PR DESCRIPTION
- Implements a concept of "validation" for automation, so you can perform custom validations
- Stop requiring both custom_fields and user_fields, allow only 1
- Fix issue with Periodical Selector not working at all in a development environment