### PR TITLE
DEV: improves placeholders/fields

### DIFF
--- a/app/models/discourse_automation/automation.rb
+++ b/app/models/discourse_automation/automation.rb
@@ -130,9 +130,6 @@ module DiscourseAutomation
 
     def trigger!(context = {})
       if enabled
-        # we need this unconditionally for testing
-        scriptable = DiscourseAutomation::Scriptable.new(script)
-
         if scriptable.background && !running_in_background
           trigger_in_background!(context)
         else
@@ -143,11 +140,11 @@ module DiscourseAutomation
     end
 
     def triggerable
-      trigger && DiscourseAutomation::Triggerable.new(trigger)
+      trigger && @triggerable ||= DiscourseAutomation::Triggerable.new(trigger, self)
     end
 
     def scriptable
-      script && DiscourseAutomation::Scriptable.new(script)
+      script && @scriptable ||= DiscourseAutomation::Scriptable.new(script, self)
     end
 
     def serialized_fields

--- a/app/serializers/discourse_automation/automation_serializer.rb
+++ b/app/serializers/discourse_automation/automation_serializer.rb
@@ -28,7 +28,9 @@ module DiscourseAutomation
     end
 
     def placeholders
-      (scriptable&.placeholders || []) + (triggerable&.placeholders || [])
+      DiscourseAutomation
+        .filter_by_trigger(scriptable&.placeholders || [], object.trigger)
+        .map { |placeholder| placeholder[:name] } + (triggerable&.placeholders || [])
     end
 
     def script

--- a/app/serializers/discourse_automation/automation_serializer.rb
+++ b/app/serializers/discourse_automation/automation_serializer.rb
@@ -28,7 +28,7 @@ module DiscourseAutomation
     end
 
     def placeholders
-      (scriptable.placeholders || []) + (triggerable.placeholders || [])
+      (scriptable&.placeholders || []) + (triggerable&.placeholders || [])
     end
 
     def script
@@ -47,11 +47,7 @@ module DiscourseAutomation
         forced_triggerable: scriptable.forced_triggerable,
         not_found: scriptable.not_found,
         templates:
-          process_templates(
-            scriptable.fields.filter do |f|
-              !f[:triggerable] || f[:triggerable].to_sym == object.trigger&.to_sym
-            end,
-          ),
+          process_templates(filter_fields_with_priority(scriptable.fields, object.trigger&.to_sym)),
         fields: process_fields(object.fields.where(target: "script")),
       }
     end
@@ -65,14 +61,28 @@ module DiscourseAutomation
         name: I18n.t("#{key}.#{object.trigger}.title"),
         description: I18n.t("#{key}.#{object.trigger}.description"),
         doc: I18n.exists?(doc_key, :en) ? I18n.t(doc_key) : nil,
-        not_found: triggerable.not_found,
-        templates: process_templates(triggerable.fields),
+        not_found: triggerable&.not_found,
+        templates: process_templates(triggerable&.fields || []),
         fields: process_fields(object.fields.where(target: "trigger")),
-        settings: triggerable.settings,
+        settings: triggerable&.settings,
       }
     end
 
     private
+
+    def filter_fields_with_priority(arr, trigger)
+      unique_with_priority = {}
+
+      arr.each do |item|
+        name = item[:name]
+        if (item[:triggerable]&.to_sym == trigger&.to_sym || item[:triggerable].nil?) &&
+             (!unique_with_priority.key?(name) || unique_with_priority[name][:triggerable].nil?)
+          unique_with_priority[name] = item
+        end
+      end
+
+      unique_with_priority.values
+    end
 
     def process_templates(fields)
       ActiveModel::ArraySerializer.new(
@@ -92,11 +102,11 @@ module DiscourseAutomation
     end
 
     def scriptable
-      DiscourseAutomation::Scriptable.new(object.script)
+      object.scriptable
     end
 
     def triggerable
-      DiscourseAutomation::Triggerable.new(object.trigger)
+      object.triggerable
     end
   end
 end

--- a/app/serializers/discourse_automation/template_serializer.rb
+++ b/app/serializers/discourse_automation/template_serializer.rb
@@ -6,6 +6,7 @@ module DiscourseAutomation
                :component,
                :extra,
                :accepts_placeholders,
+               :accepted_contexts,
                :read_only,
                :default_value,
                :is_required
@@ -32,6 +33,10 @@ module DiscourseAutomation
 
     def accepts_placeholders
       object[:accepts_placeholders]
+    end
+
+    def accepted_contexts
+      object[:accepted_contexts]
     end
 
     def is_required

--- a/assets/javascripts/discourse/admin/models/discourse-automation-field.js
+++ b/assets/javascripts/discourse/admin/models/discourse-automation-field.js
@@ -5,7 +5,9 @@ export default class DiscourseAutomationField {
   static create(template, target, json = {}) {
     const field = new DiscourseAutomationField();
     field.acceptsPlaceholders = template.accepts_placeholders;
-    field.target = target;
+    field.acceptedContexts = template.accepted_contexts;
+    field.targetName = target.name;
+    field.targetType = target.type;
     field.name = template.name;
     field.component = template.component;
     field.isDisabled = template.read_only;
@@ -36,12 +38,13 @@ export default class DiscourseAutomationField {
   @tracked isRequired = false;
   @tracked metadata = new TrackedObject();
   @tracked name;
-  @tracked target;
+  @tracked targetType;
+  @tracked targetName;
 
   toJSON() {
     return {
       name: this.name,
-      target: this.target,
+      target: this.targetType,
       component: this.component,
       metadata: this.metadata,
     };

--- a/assets/javascripts/discourse/components/automation-field.gjs
+++ b/assets/javascripts/discourse/components/automation-field.gjs
@@ -82,7 +82,7 @@ export default class AutomationField extends Component {
   }
 
   get target() {
-    return this.args.field.target === "script"
+    return this.args.field.targetType === "script"
       ? `.scriptables.${this.args.automation.script.id.replace(/-/g, "_")}.`
       : `.triggerables.${this.args.automation.trigger.id.replace(/-/g, "_")}.`;
   }

--- a/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
+++ b/assets/javascripts/discourse/components/fields/da-custom-fields.gjs
@@ -24,7 +24,7 @@ export default class GroupField extends BaseField {
             @onChange={{this.mutValue}}
             @nameProperty={{null}}
             @valueProperty={{null}}
-            @options={{hash allowAny=true disabled=@field.isDisabled}}
+            @options={{hash allowAny=false disabled=@field.isDisabled}}
           />
           <DAFieldDescription @description={{@description}} />
         </div>

--- a/assets/javascripts/discourse/components/fields/da-key-value-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-key-value-field.gjs
@@ -57,7 +57,7 @@ export default class KeyValueField extends BaseField {
   get value() {
     return (
       this.args.field.metadata.value ||
-      '[{"key":"example","value":"You posted %%KEY%%"}]'
+      '[{"key":"example","value":"You posted {{key}}"}]'
     );
   }
 

--- a/assets/javascripts/discourse/components/fields/da-period-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-period-field.gjs
@@ -3,6 +3,7 @@ import { Input } from "@ember/component";
 import { hash } from "@ember/helper";
 import { on } from "@ember/modifier";
 import { action } from "@ember/object";
+import { next } from "@ember/runloop";
 import { TrackedObject } from "@ember-compat/tracked-built-ins";
 import I18n from "I18n";
 import ComboBox from "select-kit/components/combo-box";
@@ -17,8 +18,17 @@ export default class PeriodField extends BaseField {
   constructor() {
     super(...arguments);
 
-    this.interval = this.args.field.metadata.value?.interval || 1;
-    this.frequency = this.args.field.metadata.value?.frequency;
+    next(() => {
+      if (!this.args.field.metadata.value) {
+        this.args.field.metadata.value = new TrackedObject({
+          interval: 1,
+          frequency: null,
+        });
+      }
+
+      this.interval = this.args.field.metadata.value.interval;
+      this.frequency = this.args.field.metadata.value.frequency;
+    });
   }
 
   get recurringLabel() {
@@ -34,24 +44,13 @@ export default class PeriodField extends BaseField {
     });
   }
 
-  ensureValue() {
-    if (!this.args.field.metadata.value) {
-      this.args.field.metadata.value = new TrackedObject({
-        interval: this.interval,
-        frequency: this.frequency,
-      });
-    }
-  }
-
   @action
   mutInterval(event) {
-    this.ensureValue();
     this.args.field.metadata.value.interval = event.target.value;
   }
 
   @action
   mutFrequency(value) {
-    this.ensureValue();
     this.args.field.metadata.value.frequency = value;
     this.frequency = value;
   }

--- a/assets/javascripts/discourse/components/fields/da-pms-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-pms-field.gjs
@@ -47,7 +47,7 @@ export default class PmsField extends BaseField {
             <div class="controls">
               <div class="field-wrapper">
                 <Input
-                  id={{concat @field.target @field.name "title"}}
+                  id={{concat @field.targetType @field.name "title"}}
                   @value={{pm.title}}
                   class="pm-input pm-title"
                   {{on "input" (fn this.mutPmTitle pm)}}

--- a/assets/javascripts/discourse/components/fields/da-user-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-user-field.gjs
@@ -1,11 +1,33 @@
-import { hash } from "@ember/helper";
+import { fn, hash } from "@ember/helper";
 import { action } from "@ember/object";
+import I18n from "I18n";
 import UserChooser from "select-kit/components/user-chooser";
 import BaseField from "./da-base-field";
 import DAFieldDescription from "./da-field-description";
 import DAFieldLabel from "./da-field-label";
 
 export default class UserField extends BaseField {
+  @action
+  onChangeUsername(usernames) {
+    this.mutValue(usernames[0]);
+  }
+
+  @action
+  modifyContent(field, content) {
+    content = field.acceptedContexts
+      .map((context) => {
+        return {
+          name: I18n.t(
+            `discourse_automation.scriptables.${field.targetName}.fields.${field.name}.${context}_context`
+          ),
+          username: context,
+        };
+      })
+      .concat(content);
+
+    return content;
+  }
+
   <template>
     <section class="field user-field">
       <div class="control-group">
@@ -15,6 +37,7 @@ export default class UserField extends BaseField {
           <UserChooser
             @value={{@field.metadata.value}}
             @onChange={{this.onChangeUsername}}
+            @modifyContent={{fn this.modifyContent @field}}
             @options={{hash
               maximum=1
               excludeCurrentUser=false
@@ -27,9 +50,4 @@ export default class UserField extends BaseField {
       </div>
     </section>
   </template>
-
-  @action
-  onChangeUsername(usernames) {
-    this.mutValue(usernames[0]);
-  }
 }

--- a/assets/javascripts/discourse/components/fields/da-users-field.gjs
+++ b/assets/javascripts/discourse/components/fields/da-users-field.gjs
@@ -21,6 +21,10 @@ export default class UsersField extends BaseField {
             }}
           />
 
+          {{#if @field.metadata.allowsAutomation}}
+            <span class="help-inline error">{{@field.metadata.error}}</span>
+          {{/if}}
+
           <DAFieldDescription @description={{@description}} />
         </div>
       </div>

--- a/assets/javascripts/discourse/components/placeholders-list.gjs
+++ b/assets/javascripts/discourse/components/placeholders-list.gjs
@@ -18,8 +18,6 @@ export default class PlaceholdersList extends Component {
 
   @action
   copyPlaceholder(placeholder) {
-    this.args.onCopy(
-      `${this.args.currentValue} %%${placeholder.toUpperCase()}%%`
-    );
+    this.args.onCopy(`${this.args.currentValue}{{${placeholder}}}`);
   }
 }

--- a/assets/javascripts/discourse/controllers/admin-plugins-discourse-automation-edit.js
+++ b/assets/javascripts/discourse/controllers/admin-plugins-discourse-automation-edit.js
@@ -14,8 +14,8 @@ export default class AutomationEdit extends Controller {
   isTriggeringAutomation = false;
 
   @reads("model.automation") automation;
-  @filterBy("automationForm.fields", "target", "script") scriptFields;
-  @filterBy("automationForm.fields", "target", "trigger") triggerFields;
+  @filterBy("automationForm.fields", "targetType", "script") scriptFields;
+  @filterBy("automationForm.fields", "targetType", "trigger") triggerFields;
 
   @computed("model.automation.next_pending_automation_at")
   get nextPendingAutomationAtFormatted() {

--- a/assets/javascripts/discourse/lib/fabricators.js
+++ b/assets/javascripts/discourse/lib/fabricators.js
@@ -13,12 +13,16 @@ let sequence = 0;
 function fieldFabricator(args = {}) {
   const template = args.template || {};
   template.accepts_placeholders = args.accepts_placeholders ?? true;
+  template.accepted_contexts = args.accepted_contexts ?? [];
   template.name = args.name ?? "name";
   template.component = args.component ?? "boolean";
   template.value = args.value ?? false;
   template.is_required = args.is_required ?? false;
   template.extra = args.extra ?? {};
-  return Field.create(template, args.target ?? "script");
+  return Field.create(template, {
+    type: args.target ?? "script",
+    name: "script_name",
+  });
 }
 
 function automationFabricator(args = {}) {

--- a/assets/javascripts/discourse/routes/admin-plugins-discourse-automation-edit.js
+++ b/assets/javascripts/discourse/routes/admin-plugins-discourse-automation-edit.js
@@ -24,7 +24,14 @@ export default class AutomationEdit extends DiscourseRoute {
       const jsonField = automation[target].fields.find(
         (f) => f.name === template.name && f.component === template.component
       );
-      return Field.create(template, target, jsonField);
+      return Field.create(
+        template,
+        {
+          name: automation[target].id,
+          type: target,
+        },
+        jsonField
+      );
     });
   }
 

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -166,18 +166,15 @@ en:
           edited: Edited
         user_updated:
           fields:
-            user_profile: 
+            user_profile:
               label: User profile fields
               description: Will trigger only if the user has filled this profile data
-            custom_fields: 
+            custom_fields:
               label: User custom fields
               description: Will trigger only if the user has filled this custom field
             first_post_only:
               label: First post only
               description: Will trigger only if this post is the first post a user created
-            automation_name:
-              label: Name of the automation trigger
-              description: Allows to have different user automations. Using the same name might cause issues.
         category_created_edited:
           fields:
             restricted_category:
@@ -228,7 +225,7 @@ en:
               description: Only responds once by topic
             word_answer_list:
               label: List of word/answer pairs
-              description: "Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. The `key` can be left blank to respond to all triggers, regardless of content. Note that `value` accepts `%%KEY%%` as a placeholder to be replaced by the value of `key` in the reply. Note that `key` will be evaluated as a regex, and special chars like `.` should be escaped if you actually mean a dot, eg: `\\.`"
+              description: "Defines a list of key/value groups, where the `key` is the searched term, and `value` the text of the reply. The `key` can be left blank to respond to all triggers, regardless of content. Note that `value` accepts `{{key}}` as a placeholder to be replaced by the value of `key` in the reply. Note that `key` will be evaluated as a regex, and special chars like `.` should be escaped if you actually mean a dot, eg: `\\.`"
             answering_user:
               label: Answering user
               description: Defaults to System user
@@ -241,6 +238,8 @@ en:
           fields:
             creator:
               label: Creator
+              post_creator_context: The creator of the post
+              updated_user_context: The updated user
             topic:
               label: Topic ID
             post:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -172,9 +172,9 @@ en:
             custom_fields:
               label: User custom fields
               description: Will trigger only if the user has filled this custom field
-            first_post_only:
-              label: First post only
-              description: Will trigger only if this post is the first post a user created
+            never_posted:
+              label: Never posted
+              description: Will trigger only if the user has never posted
         category_created_edited:
           fields:
             restricted_category:

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -168,13 +168,13 @@ en:
           fields:
             user_profile:
               label: User profile fields
-              description: Will trigger only if the user has filled this profile data
+              description: Will trigger only if the user has filled all these fields
             custom_fields:
               label: User custom fields
-              description: Will trigger only if the user has filled this custom field
-            never_posted:
-              label: Never posted
-              description: Will trigger only if the user has never posted
+              description: Will trigger only if the user has filled all these fields
+            once_per_user:
+              label: Once per user
+              description: Will trigger only once per user
         category_created_edited:
           fields:
             restricted_category:

--- a/config/locales/client.he.yml
+++ b/config/locales/client.he.yml
@@ -158,9 +158,6 @@ he:
             first_post_only:
               label: פוסט ראשון בלבד
               description: יוזנק רק אם הפוסט הזה הוא הפוסט הראשון שיצר המשתמש
-            automation_name:
-              label: שם הזנקת האוטומציה
-              description: מאפשר לך להקים מגוון אוטומציות משתמש. שם זהה יכול לגרום לבעיות.
         category_created_edited:
           fields:
             restricted_category:

--- a/lib/discourse_automation/engine.rb
+++ b/lib/discourse_automation/engine.rb
@@ -5,4 +5,17 @@ module ::DiscourseAutomation
     engine_name PLUGIN_NAME
     isolate_namespace DiscourseAutomation
   end
+
+  def self.filter_by_trigger(items, trigger)
+    trigger = trigger.to_sym
+
+    indexed_items =
+      items.each_with_object({}) do |item, acc|
+        if item[:triggerable] == trigger || item[:triggerable].nil?
+          acc[item[:name]] = item if acc[item[:name]].nil? || item[:triggerable] == trigger
+        end
+      end
+
+    indexed_items.values
+  end
 end

--- a/lib/discourse_automation/engine.rb
+++ b/lib/discourse_automation/engine.rb
@@ -7,7 +7,7 @@ module ::DiscourseAutomation
   end
 
   def self.filter_by_trigger(items, trigger)
-    trigger = trigger.to_sym
+    trigger = trigger&.to_sym
 
     indexed_items =
       items.each_with_object({}) do |item, acc|

--- a/lib/discourse_automation/event_handlers.rb
+++ b/lib/discourse_automation/event_handlers.rb
@@ -73,9 +73,10 @@ module DiscourseAutomation
       DiscourseAutomation::Automation
         .where(trigger: name, enabled: true)
         .find_each do |automation|
-          # if automation.trigger_field("first_post_only")["value"]
-          #   next if user.user_stat.post_count != 1
-          # end
+          never_posted = automation.trigger_field("never_posted")["value"]
+          if never_posted
+            next if user.user_stat.post_count > 0
+          end
 
           required_custom_fields = automation.trigger_field("custom_fields")
           user_data = {}

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -2,7 +2,13 @@
 
 module DiscourseAutomation
   class Scriptable
-    attr_reader :fields, :name, :not_found, :forced_triggerable, :background, :automation
+    attr_reader :fields,
+                :name,
+                :not_found,
+                :forced_triggerable,
+                :background,
+                :automation,
+                :placeholders
 
     @@plugin_triggerables ||= {}
 
@@ -67,16 +73,14 @@ module DiscourseAutomation
       end
     end
 
-    def placeholders
-      @placeholders.uniq.compact.map(&:to_sym)
-    end
-
-    def placeholder(*args)
-      if args.present?
-        @placeholders << args[0]
-      elsif block_given?
-        @placeholders =
-          @placeholders.concat(Array(yield(@automation.serialized_fields, @automation)))
+    def placeholder(name = nil, triggerable: nil, &block)
+      if block_given?
+        result = yield(@automation.serialized_fields, @automation)
+        Array(result).each do |name|
+          @placeholders << { name: name.to_sym, triggerable: triggerable&.to_sym }
+        end
+      elsif name
+        @placeholders << { name: name.to_sym, triggerable: triggerable&.to_sym }
       end
     end
 

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -14,6 +14,8 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
   field :post, component: :post, required: true, accepts_placeholders: true
 
   placeholder :creator_username
+  placeholder :updated_user_username
+  placeholder :updated_user_name
 
   triggerables %i[recurring point_in_time user_updated]
 
@@ -41,6 +43,8 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
       user = User.find(context["user"].id)
       placeholders["username"] = user.username
       placeholders["name"] = user.name
+      placeholders["updated_user_username"] = user.username
+      placeholders["updated_user_name"] = user.name
       placeholders = placeholders.merge(user_profile_data, user_custom_fields)
     end
 

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -8,20 +8,20 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
   placeholder :creator_username
 
   field :creator, component: :user
-  field :creator, component: :user, triggerable: :user_updated, accepted_contexts: ["updated_user"]
+  field :creator, component: :user, triggerable: :user_updated, accepted_contexts: [:updated_user]
 
   field :topic, component: :text, required: true
   field :post, component: :post, required: true, accepts_placeholders: true
 
   placeholder :creator_username
-  placeholder :updated_user_username
-  placeholder :updated_user_name
+  placeholder :updated_user_username, triggerable: :user_updated
+  placeholder :updated_user_name, triggerable: :user_updated
 
   triggerables %i[recurring point_in_time user_updated]
 
   script do |context, fields, automation|
     creator_username = fields.dig("creator", "value")
-    creator_username = context["user"]&.username if creator_username == "updated_user"
+    creator_username = context["user"]&.username if creator_username == :updated_user
     creator_username ||= Discourse.system_user.username
 
     topic_id = fields.dig("topic", "value")

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -8,13 +8,20 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
   placeholder :creator_username
 
   field :creator, component: :user
+  field :creator, component: :user, triggerable: :user_updated, accepted_contexts: ["updated_user"]
+
   field :topic, component: :text, required: true
-  field :post, component: :post, required: true
+  field :post, component: :post, required: true, accepts_placeholders: true
+
+  placeholder :creator_username
 
   triggerables %i[recurring point_in_time user_updated]
 
   script do |context, fields, automation|
-    creator_username = fields.dig("creator", "value") || Discourse.system_user.username
+    creator_username = fields.dig("creator", "value")
+    creator_username = context["user"]&.username if creator_username == "updated_user"
+    creator_username ||= Discourse.system_user.username
+
     topic_id = fields.dig("topic", "value")
     post_raw = fields.dig("post", "value")
 
@@ -30,21 +37,20 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
       user_data[:custom_fields]&.each do |k, v|
         user_custom_fields[k.gsub(/\s+/, "_").underscore] = v
       end
+
       user = User.find(context["user"].id)
       placeholders["username"] = user.username
       placeholders["name"] = user.name
       placeholders = placeholders.merge(user_profile_data, user_custom_fields)
-
-      post_raw = utils.apply_placeholders(post_raw, placeholders)
     end
+
+    post_raw = utils.apply_placeholders(post_raw, placeholders)
 
     new_post = PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator &&
       topic
+
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED && new_post.persisted?
-      user.user_custom_fields.create(
-        name: automation.trigger_field("automation_name")["value"],
-        value: "true",
-      )
+      user.user_custom_fields.create(name: automation.name, value: "true")
     end
   end
 end

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -60,8 +60,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
       next
     end
 
-    new_post = PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator &&
-      topic
+    new_post = PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create!
 
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED && new_post.persisted?
       user.user_custom_fields.create(name: automation.name, value: "true")

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -21,7 +21,7 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
 
   script do |context, fields, automation|
     creator_username = fields.dig("creator", "value")
-    creator_username = context["user"]&.username if creator_username == :updated_user
+    creator_username = context["user"]&.username if creator_username == "updated_user"
     creator_username ||= Discourse.system_user.username
 
     topic_id = fields.dig("topic", "value")
@@ -49,6 +49,16 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     end
 
     post_raw = utils.apply_placeholders(post_raw, placeholders)
+
+    if !creator
+      Rails.logger.warn "[discourse-automation] creator with username: `#{creator_username}` was not found"
+      next
+    end
+
+    if !topic
+      Rails.logger.warn "[discourse-automation] topic with id: `#{topic_id}` was not found"
+      next
+    end
 
     new_post = PostCreator.new(creator, topic_id: topic_id, raw: post_raw).create! if creator &&
       topic

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -5,9 +5,8 @@ class DiscourseAutomation::Triggerable
 end
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
-  field :automation_name, component: :text, required: true
-  field :custom_fields, component: :custom_fields
-  field :user_profile, component: :user_profile
+  field :custom_fields, component: :custom_fields, required: true
+  field :user_profile, component: :user_profile, required: true
   field :first_post_only, component: :boolean
 
   validate do
@@ -24,5 +23,11 @@ DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDA
     else
       true
     end
+  end
+
+  placeholder do |fields, automation|
+    custom_fields = automation.trigger_field("custom_fields")["value"] || []
+    user_profile = automation.trigger_field("user_profile")["value"] || []
+    custom_fields + user_profile
   end
 end

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -5,8 +5,8 @@ class DiscourseAutomation::Triggerable
 end
 
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
-  field :custom_fields, component: :custom_fields, required: true
-  field :user_profile, component: :user_profile, required: true
+  field :custom_fields, component: :custom_fields
+  field :user_profile, component: :user_profile
   field :first_post_only, component: :boolean
 
   validate do

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -7,7 +7,7 @@ end
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
   field :custom_fields, component: :custom_fields
   field :user_profile, component: :user_profile
-  field :first_post_only, component: :boolean
+  field :never_posted, component: :boolean
 
   validate do
     has_triggers = has_trigger_field?(:custom_fields) && has_trigger_field?(:user_profile)

--- a/lib/discourse_automation/triggers/user_updated.rb
+++ b/lib/discourse_automation/triggers/user_updated.rb
@@ -7,7 +7,7 @@ end
 DiscourseAutomation::Triggerable.add(DiscourseAutomation::Triggerable::USER_UPDATED) do
   field :custom_fields, component: :custom_fields
   field :user_profile, component: :user_profile
-  field :never_posted, component: :boolean
+  field :once_per_user, component: :boolean
 
   validate do
     has_triggers = has_trigger_field?(:custom_fields) && has_trigger_field?(:user_profile)

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -92,7 +92,12 @@ describe DiscourseAutomation::Scriptable do
   describe "#placeholders" do
     it "returns the specified placeholders" do
       expect(automation.scriptable.placeholders).to eq(
-        [:foo, :bar, :"baz-#{automation.id}", :"foo-baz-#{automation.id}"],
+        [
+          { name: :foo, triggerable: nil },
+          { name: :bar, triggerable: nil },
+          { name: :"baz-#{automation.id}", triggerable: nil },
+          { name: :"foo-baz-#{automation.id}", triggerable: nil },
+        ],
       )
     end
   end

--- a/spec/lib/triggerable_spec.rb
+++ b/spec/lib/triggerable_spec.rb
@@ -3,6 +3,19 @@
 require_relative "../discourse_automation_helper"
 
 describe DiscourseAutomation::Triggerable do
+  before do
+    DiscourseAutomation::Triggerable.add("cats_everywhere") do
+      placeholder :foo
+      placeholder :bar
+      placeholder { |fields, automation| "baz-#{automation.id}" }
+      placeholder { |fields, automation| ["foo-baz-#{automation.id}"] }
+    end
+
+    DiscourseAutomation::Triggerable.add("dog") { field :kind, component: :text }
+
+    DiscourseAutomation::Scriptable.add("only_dogs") { triggerable! :dog, { kind: "good_boy" } }
+  end
+
   fab!(:automation) { Fabricate(:automation, trigger: "foo") }
 
   describe "#setting" do
@@ -12,6 +25,16 @@ describe DiscourseAutomation::Triggerable do
       triggerable = DiscourseAutomation::Triggerable.new(automation.trigger)
 
       expect(triggerable.settings[:bar]).to eq(:baz)
+    end
+  end
+
+  describe "#placeholders" do
+    fab!(:automation) { Fabricate(:automation, trigger: "cats_everywhere") }
+
+    it "returns the specified placeholders" do
+      expect(automation.triggerable.placeholders).to eq(
+        [:foo, :bar, :"baz-#{automation.id}", :"foo-baz-#{automation.id}"],
+      )
     end
   end
 

--- a/spec/scripts/auto_responder_spec.rb
+++ b/spec/scripts/auto_responder_spec.rb
@@ -33,8 +33,8 @@ describe "AutoResponder" do
         "key-value",
         {
           value: [
-            { key: "fooz?|bar", value: "this is %%KEY%%" },
-            { key: "bar", value: "this is %%KEY%%" },
+            { key: "fooz?|bar", value: "this is {{key}}" },
+            { key: "bar", value: "this is {{key}}" },
           ].to_json,
         },
       )

--- a/spec/scripts/gift_exchange_spec.rb
+++ b/spec/scripts/gift_exchange_spec.rb
@@ -34,8 +34,8 @@ describe "GiftExchange" do
       {
         value: [
           {
-            title: "Gift %%YEAR%%",
-            raw: "@%%GIFTER_USERNAME%% you should send a gift to %%GIFTEE_USERNAME%%",
+            title: "Gift {{year}}",
+            raw: "@{{gifter_username}} you should send a gift to {{giftee_username}}",
           },
         ],
       },

--- a/spec/scripts/send_pms_spec.rb
+++ b/spec/scripts/send_pms_spec.rb
@@ -21,8 +21,8 @@ describe "SendPms" do
       {
         value: [
           {
-            title: "A message from %%SENDER_USERNAME%%",
-            raw: "This is a message sent to @%%RECEIVER_USERNAME%%",
+            title: "A message from {{sender_username}}",
+            raw: "This is a message sent to @{{receiver_username}}",
           },
         ],
       },
@@ -100,8 +100,8 @@ describe "SendPms" do
         {
           value: [
             {
-              title: "A message from %%SENDER_USERNAME%%",
-              raw: "This is a message sent to @%%RECEIVER_USERNAME%%",
+              title: "A message from {{sender_username}}",
+              raw: "This is a message sent to @{{receiver_username}}",
               delay: 1,
             },
           ],
@@ -122,8 +122,8 @@ describe "SendPms" do
         {
           value: [
             {
-              title: "A message from %%SENDER_USERNAME%%",
-              raw: "This is a message sent to @%%RECEIVER_USERNAME%%",
+              title: "A message from {{sender_username}}",
+              raw: "This is a message sent to @{{receiver_username}}",
               delay: 1,
               prefers_encrypt: false,
             },

--- a/spec/scripts/user_global_notice_spec.rb
+++ b/spec/scripts/user_global_notice_spec.rb
@@ -69,7 +69,7 @@ describe "UserGlobalNotice" do
       automation_1.upsert_field!(
         "notice",
         "message",
-        { value: "notice for %%USERNAME%%" },
+        { value: "notice for {{username}}" },
         target: "script",
       )
       automation_1.upsert_field!("level", "choices", { value: "success" }, target: "script")

--- a/spec/triggers/user_updated_spec.rb
+++ b/spec/triggers/user_updated_spec.rb
@@ -35,21 +35,17 @@ describe "UserUpdated" do
 
   context "when custom_fields and user_profile are blank" do
     let(:automation) do
-      Fabricate(
-        :automation,
-        trigger: DiscourseAutomation::Triggerable::USER_UPDATED,
-      ).tap do |automation|
-        automation.upsert_field!("custom_fields", "custom_fields", { value: [] }, target: "trigger")
-        automation.upsert_field!("user_profile", "user_profile", { value: [] }, target: "trigger")
-      end
+      Fabricate(:automation, trigger: DiscourseAutomation::Triggerable::USER_UPDATED)
     end
 
     it "adds an error to the automation" do
-      expect(automation.save).to eq(false)
-      errors = automation.errors.full_messages
-      expect(errors).to include(
-        I18n.t("discourse_automation.triggerables.errors.custom_fields_or_user_profile_required"),
-      )
+      expect {
+        automation.upsert_field!("custom_fields", "custom_fields", { value: [] }, target: "trigger")
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect {
+        automation.upsert_field!("user_profile", "user_profile", { value: [] }, target: "trigger")
+      }.to raise_error(ActiveRecord::RecordInvalid)
     end
   end
 

--- a/spec/triggers/user_updated_spec.rb
+++ b/spec/triggers/user_updated_spec.rb
@@ -39,12 +39,6 @@ describe "UserUpdated" do
         :automation,
         trigger: DiscourseAutomation::Triggerable::USER_UPDATED,
       ).tap do |automation|
-        automation.upsert_field!(
-          "automation_name",
-          "text",
-          { value: "Test Automation" },
-          target: "trigger",
-        )
         automation.upsert_field!("custom_fields", "custom_fields", { value: [] }, target: "trigger")
         automation.upsert_field!("user_profile", "user_profile", { value: [] }, target: "trigger")
       end


### PR DESCRIPTION
- Adds a new `accepted_contexts` which will allow fields value to be derived from context

```ruby
field :creator, component: :user, accepted_contexts: ["updated_user"]
```

The value of user in the script will now be "updated_user" which allows the developer to override it with a custom value.

- `placeholder` now accepts a block to define more dynamic placeholders:

```ruby
placeholder do |field, automation|
  "something-#{automation.id}" # note we can also return an array here
end
```

- Templates now accept mustache templating syntax:

```
{{username}}

{{#foo}}
  bar
{{/foo}}
```

- Allows to set multiple times the same field, this is useful if you have different setup depending on the triggerable:

```
field :creator, component: :user
field :creator, component: :user, triggerable: :foo, accepted_contexts: [:bar]
```

- Fixes a bug where new instances of scriptables/triggerables were created at unexpected moments and making us lose state. `sciptable` and `triggerable` are now defined and memoized on the automation object.

- placeholders from scripts now accept a triggerable:

```ruby
placeholder :foo, triggerable: :bar
placeholder(triggerable: :baz) do
  "something"
end
```