### PR TITLE
FIX: correctly format placeholders

### DIFF
--- a/app/serializers/discourse_automation/automation_serializer.rb
+++ b/app/serializers/discourse_automation/automation_serializer.rb
@@ -28,9 +28,15 @@ module DiscourseAutomation
     end
 
     def placeholders
-      DiscourseAutomation
-        .filter_by_trigger(scriptable&.placeholders || [], object.trigger)
-        .map { |placeholder| placeholder[:name] } + (triggerable&.placeholders || [])
+      scriptable_placeholders =
+        DiscourseAutomation
+          .filter_by_trigger(scriptable&.placeholders || [], object.trigger)
+          .map { |placeholder| placeholder[:name] }
+      triggerable_placeholders = triggerable&.placeholders || []
+
+      (scriptable_placeholders + triggerable_placeholders).map do |placeholder|
+        placeholder.to_s.gsub(/\s+/, "_").underscore
+      end
     end
 
     def script

--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -34,12 +34,11 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED
       user = context["user"]
       user_data = context["user_data"]
-      user_profile_data = user_data[:profile_data]
+      user_profile_data = user_data[:profile_data] || {}
       user_custom_fields = {}
       user_data[:custom_fields]&.each do |k, v|
         user_custom_fields[k.gsub(/\s+/, "_").underscore] = v
       end
-
       user = User.find(context["user"].id)
       placeholders["username"] = user.username
       placeholders["name"] = user.name

--- a/spec/serializers/automation_serializer_spec.rb
+++ b/spec/serializers/automation_serializer_spec.rb
@@ -83,7 +83,7 @@ describe DiscourseAutomation::AutomationSerializer do
     end
   end
 
-  context "when placeholders have triggerable" do
+  describe "#placeholders" do
     before do
       DiscourseAutomation::Scriptable.add("foo_bar") do
         version 1
@@ -95,6 +95,7 @@ describe DiscourseAutomation::AutomationSerializer do
         placeholder :bar, triggerable: :something
         placeholder(triggerable: :user_updated) { :cool }
         placeholder(triggerable: :whatever) { :not_cool }
+        placeholder { "Why not" }
 
         triggerables %i[user_updated something whatever]
       end
@@ -102,7 +103,7 @@ describe DiscourseAutomation::AutomationSerializer do
 
     fab!(:automation) { Fabricate(:automation, script: :foo_bar, trigger: :user_updated) }
 
-    it "correctly filters placeholders" do
+    it "correctly renders placeholders" do
       serializer =
         DiscourseAutomation::AutomationSerializer.new(
           automation,
@@ -110,7 +111,7 @@ describe DiscourseAutomation::AutomationSerializer do
           root: false,
         )
 
-      expect(serializer.placeholders).to eq(%i[foo bar cool])
+      expect(serializer.placeholders).to eq(%w[foo bar cool why_not])
     end
   end
 end


### PR DESCRIPTION
Custom fields can be free form, eg: "Foo bar". We want to be sure this is rendered in the template as "foo_bar" as this is also how we will fill the placeholders map in scripts.