### PR TITLE
DEV: retry 3 times background trigger

### DIFF
--- a/app/jobs/regular/discourse_automation_trigger.rb
+++ b/app/jobs/regular/discourse_automation_trigger.rb
@@ -2,6 +2,21 @@
 
 module Jobs
   class DiscourseAutomationTrigger < ::Jobs::Base
+    RETRY_TIMES = [5.minute, 15.minute, 120.minute]
+
+    sidekiq_options retry: RETRY_TIMES.size
+
+    sidekiq_retry_in do |count, exception|
+      # returning nil/0 will trigger the default sidekiq
+      # retry formula
+      #
+      # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
+      case exception.wrapped
+      when SocketError
+        return RETRY_TIMES[count]
+      end
+    end
+
     def execute(args)
       automation = DiscourseAutomation::Automation.find_by(id: args[:automation_id], enabled: true)
 


### PR DESCRIPTION
In case of error while evaluating a script running in the background, the job will retry after 5/15/120 minutes.

Note this retry syntax is quite convulted at the moment and should be improved in the future.