### PR TITLE
DEV: Fix incorrect retry time for `Jobs::DiscourseAutomationTrigger`

### DIFF
--- a/app/jobs/regular/discourse_automation_trigger.rb
+++ b/app/jobs/regular/discourse_automation_trigger.rb
@@ -11,10 +11,7 @@ module Jobs
       # retry formula
       #
       # See https://github.com/mperham/sidekiq/blob/3330df0ee37cfd3e0cd3ef01e3e66b584b99d488/lib/sidekiq/job_retry.rb#L216-L234
-      case exception.wrapped
-      when SocketError
-        return RETRY_TIMES[count]
-      end
+      RETRY_TIMES[count]
     end
 
     def execute(args)


### PR DESCRIPTION
Why this change?

This is a follow up to 83ef80f1a6594b4e67c4b6f006ebb6ec1127bdf5. The
`SocketError` was likely coped from another job which is not what we
want. Instead we want to unconditionally set a custom retry duration.
