### PR TITLE
FIX: Skip closed/archived topics during post script runs

### DIFF
--- a/lib/discourse_automation/scripts/post.rb
+++ b/lib/discourse_automation/scripts/post.rb
@@ -31,6 +31,11 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
     creator = User.find_by(username: creator_username)
     topic = Topic.find_by(id: topic_id)
 
+    if !topic || topic.closed? || topic.archived?
+      Rails.logger.warn "[discourse-automation] topic with id: `#{topic_id}` was not found"
+      next
+    end
+
     if context["kind"] == DiscourseAutomation::Triggerable::USER_UPDATED
       user = context["user"]
       user_data = context["user_data"]
@@ -51,11 +56,6 @@ DiscourseAutomation::Scriptable.add(DiscourseAutomation::Scriptable::POST) do
 
     if !creator
       Rails.logger.warn "[discourse-automation] creator with username: `#{creator_username}` was not found"
-      next
-    end
-
-    if !topic
-      Rails.logger.warn "[discourse-automation] topic with id: `#{topic_id}` was not found"
       next
     end
 

--- a/spec/scripts/post_spec.rb
+++ b/spec/scripts/post_spec.rb
@@ -70,6 +70,18 @@ describe "Post" do
         expect(topic_1.posts.last.raw).to eq(raw)
       }.to change { topic_1.posts.count }.by(1)
     end
+
+    it "does not create post on a closed topic" do
+      topic_1.update_status(:closed, true, topic_1.user)
+
+      expect { automation.trigger! }.not_to change { topic_1.posts.count }
+    end
+
+    it "does not create post on an archived topic" do
+      topic_1.update_status(:archived, true, topic_1.user)
+
+      expect { automation.trigger! }.not_to change { topic_1.posts.count }
+    end
   end
 
   context "when using user_updated trigger" do


### PR DESCRIPTION
Currently, the post script will continue adding posts to the configured topic even when it's closed/archived.

This change updates the script to skip closed/archived topics.