### PR TITLE
FEATURE: add emails to send pm in scriptable utils

### DIFF
--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -228,8 +228,8 @@ module DiscourseAutomation
             return
           end
 
-          if (pm[:target_usernames] || []).empty? && (pm[:target_group_names] || []).empty? &&
-               (pm[:target_emails] || []).empty?
+          if Array.wrap(pm[:target_usernames]).empty? &&
+               Array.wrap(pm[:target_group_names]).empty? && Array.wrap(pm[:target_emails]).empty?
             Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames, groups or emails"
             return
           end
@@ -262,9 +262,9 @@ module DiscourseAutomation
 
           post_created = false
           pm = pm.merge(archetype: Archetype.private_message)
-          pm[:target_usernames] = (pm[:target_usernames] || []).join(",")
-          pm[:target_group_names] = (pm[:target_group_names] || []).join(",")
-          pm[:target_emails] = (pm[:target_emails] || []).join(",")
+          pm[:target_usernames] = Array.wrap(pm[:target_usernames]).join(",")
+          pm[:target_group_names] = Array.wrap(pm[:target_group_names]).join(",")
+          pm[:target_emails] = Array.wrap(pm[:target_emails]).join(",")
 
           if pm[:target_usernames].blank? && pm[:target_group_names].blank? &&
                pm[:target_emails].blank?

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -228,8 +228,9 @@ module DiscourseAutomation
             return
           end
 
-          if (pm[:target_usernames] || []).empty? && (pm[:target_group_names] || []).empty?
-            Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames or groups"
+          if (pm[:target_usernames] || []).empty? && (pm[:target_group_names] || []).empty? &&
+               (pm[:target_emails] || []).empty?
+            Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames, groups or emails"
             return
           end
 
@@ -251,12 +252,22 @@ module DiscourseAutomation
             end
           end
 
+          if pm[:target_emails].present?
+            valid_emails = pm[:target_emails].select { |email| Email.is_valid?(email) }
+            if valid_emails.length != pm[:target_emails].length
+              non_existing_targets += pm[:target_emails] - valid_emails
+              pm[:target_emails] = valid_emails
+            end
+          end
+
           post_created = false
           pm = pm.merge(archetype: Archetype.private_message)
           pm[:target_usernames] = (pm[:target_usernames] || []).join(",")
           pm[:target_group_names] = (pm[:target_group_names] || []).join(",")
+          pm[:target_emails] = (pm[:target_emails] || []).join(",")
 
-          if pm[:target_usernames].blank? && pm[:target_group_names].blank?
+          if pm[:target_usernames].blank? && pm[:target_group_names].blank? &&
+               pm[:target_emails].blank?
             Rails.logger.warn "[discourse-automation] Did not send PM #{pm[:title]} - no valid targets exist"
             return
           elsif non_existing_targets.any?

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -232,7 +232,8 @@ module DiscourseAutomation
           pm[:target_group_names] = Array.wrap(pm[:target_group_names])
           pm[:target_emails] = Array.wrap(pm[:target_emails])
 
-          if pm[:target_usernames].empty? && pm[:target_group_names].empty? && pm[:target_emails].empty?
+          if pm[:target_usernames].empty? && pm[:target_group_names].empty? &&
+               pm[:target_emails].empty?
             Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames, groups or emails"
             return
           end

--- a/lib/discourse_automation/scriptable.rb
+++ b/lib/discourse_automation/scriptable.rb
@@ -228,8 +228,11 @@ module DiscourseAutomation
             return
           end
 
-          if Array.wrap(pm[:target_usernames]).empty? &&
-               Array.wrap(pm[:target_group_names]).empty? && Array.wrap(pm[:target_emails]).empty?
+          pm[:target_usernames] = Array.wrap(pm[:target_usernames])
+          pm[:target_group_names] = Array.wrap(pm[:target_group_names])
+          pm[:target_emails] = Array.wrap(pm[:target_emails])
+
+          if pm[:target_usernames].empty? && pm[:target_group_names].empty? && pm[:target_emails].empty?
             Rails.logger.warn "[discourse-automation] Did not send PM - no target usernames, groups or emails"
             return
           end
@@ -262,9 +265,9 @@ module DiscourseAutomation
 
           post_created = false
           pm = pm.merge(archetype: Archetype.private_message)
-          pm[:target_usernames] = Array.wrap(pm[:target_usernames]).join(",")
-          pm[:target_group_names] = Array.wrap(pm[:target_group_names]).join(",")
-          pm[:target_emails] = Array.wrap(pm[:target_emails]).join(",")
+          pm[:target_usernames] = pm[:target_usernames].join(",")
+          pm[:target_group_names] = pm[:target_group_names].join(",")
+          pm[:target_emails] = pm[:target_emails].join(",")
 
           if pm[:target_usernames].blank? && pm[:target_group_names].blank? &&
                pm[:target_emails].blank?

--- a/spec/lib/scriptable_spec.rb
+++ b/spec/lib/scriptable_spec.rb
@@ -343,6 +343,46 @@ describe DiscourseAutomation::Scriptable do
           expect(Topic.last.allowed_groups).to contain_exactly(group)
         end
       end
+
+      context "when pm target_emails with valid email" do
+        it "sends the pm" do
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Private Message Title",
+                raw: "0123456789" * 25 + "a",
+                target_emails: ["john@doe.com"],
+              },
+            )
+          }.to change { Topic.count }
+        end
+      end
+
+      context "when pm target_emails contain an invalid email" do
+        it "skips sending if there is only one target" do
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Private Message Title",
+                raw: "0123456789" * 25 + "a",
+                target_emails: ["invalid-email"],
+              },
+            )
+          }.not_to change { Topic.count }
+        end
+
+        it "sends the pm without the invalid email" do
+          expect {
+            DiscourseAutomation::Scriptable::Utils.send_pm(
+              {
+                title: "Private Message Title",
+                raw: "0123456789" * 25 + "a",
+                target_emails: %w[invalid-email john@doe.com],
+              },
+            )
+          }.to change { Topic.count }.by(1)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Why this change?

In core the TopicCreator accepts a comma separated string for `target_emails`. Our automation script within DataExplorer allows email addresses to be specified as PM recipients, however the scriptable utils within Discourse Automation previously only accepted usernames and therefore emails weren't being sent as they didn't have an account attached and got filtered.

This change ensures emails are handled and validated in the correct way, as they passed in the correct format.