### PR TITLE
DEV: Inform self-hosted admins to remove discourse-automation

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# name: discourse-automation
+# about: Allows admins to automate actions through scripts and triggers. Customisation is made through an automatically generated UI.
+# meta_topic_id: 195773
+# version: 0.1
+# authors: jjaffeux
+# url: https://github.com/discourse/discourse-automation
+
+after_initialize do
+  class ProblemCheck::DiscourseAutomation < ProblemCheck
+    self.priority = "low"
+
+    def call
+      problem
+    end
+
+    private
+
+    def message
+      "The discourse-automation plugin has been integrated into discourse core. Please remove the plugin from your app.yml and rebuild your container."
+    end
+  end
+
+  register_problem_check ProblemCheck::DiscourseAutomation
+end


### PR DESCRIPTION
Adds this message to inform admins to remove this plugin, since it is now a core plugin.

<img width="1030" alt="Screenshot 2024-04-04 at 8 18 39 PM" src="https://github.com/discourse/discourse-automation/assets/1555215/7dc5d0e3-1774-43b0-bfc3-264ffbed0f7d">
